### PR TITLE
Save Method

### DIFF
--- a/src/bcfuse/bcfs.go
+++ b/src/bcfuse/bcfs.go
@@ -117,7 +117,10 @@ func (fs *FS[K]) Flush(ctx context.Context) error {
 	}
 
 	// Commit the transaction with the new root
-	if err := tx.Commit(ctx, newRoot); err != nil {
+	if err := tx.Save(ctx, newRoot); err != nil {
+		return fmt.Errorf("failed to save root: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 

--- a/src/bcfuse/fuse.go
+++ b/src/bcfuse/fuse.go
@@ -189,8 +189,11 @@ func (n *Node[K]) Create(ctx context.Context, name string, flags uint32, mode ui
 		return nil, nil, 0, syscall.EIO
 	}
 
-	// Commit the transaction
-	if err := tx.Commit(ctx, newRoot); err != nil {
+	// Save and Commit the transaction
+	if err := tx.Save(ctx, newRoot); err != nil {
+		return nil, nil, 0, syscall.EIO
+	}
+	if err := tx.Commit(ctx); err != nil {
 		return nil, nil, 0, syscall.EIO
 	}
 
@@ -246,8 +249,11 @@ func (n *Node[K]) Unlink(ctx context.Context, name string) syscall.Errno {
 		return syscall.EIO
 	}
 
-	// Commit the transaction
-	if err := tx.Commit(ctx, newRoot); err != nil {
+	// Save and Commit the transaction
+	if err := tx.Save(ctx, newRoot); err != nil {
+		return syscall.EIO
+	}
+	if err := tx.Commit(ctx); err != nil {
 		return syscall.EIO
 	}
 

--- a/src/bchttp/bchttp.go
+++ b/src/bchttp/bchttp.go
@@ -74,15 +74,19 @@ type InspectTxResp struct {
 	Info blobcache.TxInfo `json:"info"`
 }
 
-type CommitReq struct {
-	Root []byte `json:"root"`
-}
+type CommitReq struct{}
 
 type CommitResp struct{}
 
 type AbortReq struct{}
 
 type AbortResp struct{}
+
+type SaveReq struct {
+	Root []byte `json:"root"`
+}
+
+type SaveResp struct{}
 
 type LoadReq struct{}
 

--- a/src/bchttp/client.go
+++ b/src/bchttp/client.go
@@ -125,8 +125,8 @@ func (c *Client) InspectTx(ctx context.Context, tx blobcache.Handle) (*blobcache
 	return &resp.Info, nil
 }
 
-func (c *Client) Commit(ctx context.Context, tx blobcache.Handle, root []byte) error {
-	req := CommitReq{Root: root}
+func (c *Client) Commit(ctx context.Context, tx blobcache.Handle) error {
+	req := CommitReq{}
 	var resp CommitResp
 	return c.doJSON(ctx, "POST", c.mkTxURL(tx, "Commit"), &tx.Secret, req, &resp)
 }
@@ -135,6 +135,12 @@ func (c *Client) Abort(ctx context.Context, tx blobcache.Handle) error {
 	req := AbortReq{}
 	var resp AbortResp
 	return c.doJSON(ctx, "POST", c.mkTxURL(tx, "Abort"), &tx.Secret, req, &resp)
+}
+
+func (c *Client) Save(ctx context.Context, tx blobcache.Handle, root []byte) error {
+	req := SaveReq{Root: root}
+	var resp SaveResp
+	return c.doJSON(ctx, "POST", c.mkTxURL(tx, "Save"), &tx.Secret, req, &resp)
 }
 
 func (c *Client) Load(ctx context.Context, tx blobcache.Handle, dst *[]byte) error {

--- a/src/bchttp/server.go
+++ b/src/bchttp/server.go
@@ -168,7 +168,7 @@ func (s *Server) handleTx(w http.ResponseWriter, r *http.Request) {
 		})
 	case "Commit":
 		handleRequest(w, r, func(ctx context.Context, req CommitReq) (*CommitResp, error) {
-			if err := s.Service.Commit(ctx, h, req.Root); err != nil {
+			if err := s.Service.Commit(ctx, h); err != nil {
 				return nil, err
 			}
 			return &CommitResp{}, nil
@@ -179,6 +179,21 @@ func (s *Server) handleTx(w http.ResponseWriter, r *http.Request) {
 				return nil, err
 			}
 			return &AbortResp{}, nil
+		})
+	case "Load":
+		handleRequest(w, r, func(ctx context.Context, req LoadReq) (*LoadResp, error) {
+			var root []byte
+			if err := s.Service.Load(ctx, h, &root); err != nil {
+				return nil, err
+			}
+			return &LoadResp{Root: root}, nil
+		})
+	case "Save":
+		handleRequest(w, r, func(ctx context.Context, req SaveReq) (*SaveResp, error) {
+			if err := s.Service.Save(ctx, h, req.Root); err != nil {
+				return nil, err
+			}
+			return &SaveResp{}, nil
 		})
 	// Post and Get are special cases that does not use JSON.
 	case "Post":
@@ -213,14 +228,6 @@ func (s *Server) handleTx(w http.ResponseWriter, r *http.Request) {
 		}
 		w.Write(buf[:n])
 		return
-	case "Load":
-		handleRequest(w, r, func(ctx context.Context, req LoadReq) (*LoadResp, error) {
-			var root []byte
-			if err := s.Service.Load(ctx, h, &root); err != nil {
-				return nil, err
-			}
-			return &LoadResp{Root: root}, nil
-		})
 	case "Delete":
 		handleRequest(w, r, func(ctx context.Context, req DeleteReq) (*DeleteResp, error) {
 			if err := s.Service.Delete(ctx, h, req.CID); err != nil {

--- a/src/blobcache/blobcache.go
+++ b/src/blobcache/blobcache.go
@@ -23,8 +23,8 @@ import (
 // them from OIDs which are printed as hex.
 type CID = cadata.ID
 
-// CIDBytes is the number of bytes in a CID.
-const CIDBytes = cadata.IDSize
+// CIDSize is the number of bytes in a CID.
+const CIDSize = cadata.IDSize
 
 func ParseCID(s string) (CID, error) {
 	var ret CID
@@ -227,11 +227,14 @@ type Service interface {
 	// InspectTx returns info about a transaction.
 	InspectTx(ctx context.Context, tx Handle) (*TxInfo, error)
 	// Commit commits a transaction.
-	Commit(ctx context.Context, tx Handle, root []byte) error
+	Commit(ctx context.Context, tx Handle) error
 	// Abort aborts a transaction.
 	Abort(ctx context.Context, tx Handle) error
 	// Load loads the volume root into dst
 	Load(ctx context.Context, tx Handle, dst *[]byte) error
+	// Save writes to the volume root.
+	// Like all operations in a transaction, Save will not be visible until Commit is called.
+	Save(ctx context.Context, tx Handle, src []byte) error
 	// Post posts data to the volume
 	Post(ctx context.Context, tx Handle, salt *CID, data []byte) (CID, error)
 	// Exists checks if a CID exists in the volume

--- a/src/blobcache/blobcachetests/util.go
+++ b/src/blobcache/blobcachetests/util.go
@@ -56,7 +56,8 @@ func Modify(t testing.TB, s blobcache.Service, volh blobcache.Handle, f func(tx 
 	require.NoError(t, err)
 	data, err := f(tx)
 	require.NoError(t, err)
-	require.NoError(t, tx.Commit(ctx, data))
+	require.NoError(t, tx.Save(ctx, data))
+	require.NoError(t, tx.Commit(ctx))
 }
 
 func Load(t testing.TB, s blobcache.Service, txh blobcache.Handle) []byte {
@@ -69,9 +70,11 @@ func Load(t testing.TB, s blobcache.Service, txh blobcache.Handle) []byte {
 	return buf
 }
 
-func Commit(t testing.TB, s blobcache.Service, txh blobcache.Handle, data []byte) {
+// SaveCommit is a convenience function that saves the given data and then commits the transaction.
+func SaveCommit(t testing.TB, s blobcache.Service, txh blobcache.Handle, data []byte) {
 	ctx := testutil.Context(t)
-	require.NoError(t, s.Commit(ctx, txh, data))
+	require.NoError(t, s.Save(ctx, txh, data))
+	require.NoError(t, s.Commit(ctx, txh))
 }
 
 func Abort(t testing.TB, s blobcache.Service, txh blobcache.Handle) {

--- a/src/blobcache/tx.go
+++ b/src/blobcache/tx.go
@@ -43,15 +43,19 @@ func NewTx(s Service, h Handle, hash HashFunc, maxSize int) *Tx {
 	}
 }
 
+func (tx *Tx) Save(ctx context.Context, src []byte) error {
+	return tx.s.Save(ctx, tx.h, src)
+}
+
 func (tx *Tx) Load(ctx context.Context, dst *[]byte) error {
 	return tx.s.Load(ctx, tx.h, dst)
 }
 
-func (tx *Tx) Commit(ctx context.Context, root []byte) error {
+func (tx *Tx) Commit(ctx context.Context) error {
 	if tx.done {
 		return ErrTxDone{ID: tx.h.OID}
 	}
-	err := tx.s.Commit(ctx, tx.h, root)
+	err := tx.s.Commit(ctx, tx.h)
 	tx.done = true
 	return err
 }
@@ -133,11 +137,15 @@ func (tx *TxSalt) Load(ctx context.Context, dst *[]byte) error {
 	return tx.s.Load(ctx, tx.h, dst)
 }
 
-func (tx *TxSalt) Commit(ctx context.Context, root []byte) error {
+func (tx *TxSalt) Save(ctx context.Context, src []byte) error {
+	return tx.s.Save(ctx, tx.h, src)
+}
+
+func (tx *TxSalt) Commit(ctx context.Context) error {
 	if tx.done {
 		return ErrTxDone{ID: tx.h.OID}
 	}
-	err := tx.s.Commit(ctx, tx.h, root)
+	err := tx.s.Commit(ctx, tx.h)
 	tx.done = true
 	return err
 }

--- a/src/blobcachecmd/glfs.go
+++ b/src/blobcachecmd/glfs.go
@@ -65,7 +65,10 @@ var glfsInitCmd = star.Command{
 		if err != nil {
 			return err
 		}
-		return tx.Commit(ctx, rootData)
+		if err := tx.Save(ctx, rootData); err != nil {
+			return err
+		}
+		return tx.Commit(ctx)
 	},
 }
 
@@ -289,5 +292,8 @@ func modifyGLFS(ctx context.Context, s blobcache.Service, volh blobcache.Handle,
 		return err
 	}
 	// TODO: delete old refs
-	return tx.Commit(ctx, glfsschema.MarshalRef(root2))
+	if err := tx.Save(ctx, glfsschema.MarshalRef(root2)); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
 }

--- a/src/internal/bcnet/message.go
+++ b/src/internal/bcnet/message.go
@@ -21,40 +21,56 @@ func (mt MessageType) IsOK() bool {
 
 const (
 	MT_UNKNOWN MessageType = iota
-
 	// MT_PING is a request to ping the remote peer.
 	MT_PING
+)
 
-	MT_HANDLE_INSPECT
+// Handle messages
+const (
+	MT_HANDLE_INSPECT MessageType = 16 + iota
 	MT_HANDLE_DROP
 	MT_HANDLE_KEEP_ALIVE
+)
 
-	MT_OPEN_AS
+// Volume messages
+const (
+	MT_OPEN_AS MessageType = 32 + iota
 	MT_OPEN_FROM
 	MT_CREATE_VOLUME
 	MT_VOLUME_INSPECT
 	MT_VOLUME_AWAIT
 	MT_VOLUME_BEGIN_TX
+)
 
-	MT_TX_INSPECT
+// Tx messages
+const (
+	MT_TX_INSPECT MessageType = 48 + iota
+
 	MT_TX_COMMIT
 	MT_TX_ABORT
+
 	MT_TX_LOAD
+	MT_TX_SAVE
+
 	MT_TX_POST
 	MT_TX_POST_SALT
 	MT_TX_GET
 	MT_TX_EXISTS
 	MT_TX_DELETE
 	MT_TX_ALLOW_LINK
+)
 
+const (
 	// MT_LAYER2_TELL is used for volume implementations to communicate with other volumes.
-	MT_LAYER2_TELL
+	MT_LAYER2_TELL MessageType = 64 + iota
 	// MT_LAYER2_ASK is used for volume implementations to communicate with other volumes.
 	MT_LAYER2_ASK
 )
 
+// Response messages
 const (
 	MT_OK = 128 + iota
+
 	MT_ERROR_TIMEOUT
 	MT_ERROR_INVALID_HANDLE
 	MT_ERROR_NOT_FOUND

--- a/src/internal/bcnet/rpc_message.go
+++ b/src/internal/bcnet/rpc_message.go
@@ -78,8 +78,9 @@ type InspectTxResp struct {
 }
 
 type CommitReq struct {
-	Tx   blobcache.Handle `json:"tx"`
-	Root []byte           `json:"root"`
+	Tx blobcache.Handle `json:"tx"`
+	// Root can be optionally set to call Save before Commit.
+	Root *[]byte `json:"root,omitempty"`
 }
 
 type CommitResp struct{}
@@ -97,6 +98,13 @@ type LoadReq struct {
 type LoadResp struct {
 	Root []byte `json:"root"`
 }
+
+type SaveReq struct {
+	Tx   blobcache.Handle `json:"tx"`
+	Root []byte           `json:"root"`
+}
+
+type SaveResp struct{}
 
 type ExistsReq struct {
 	Tx   blobcache.Handle `json:"tx"`

--- a/src/internal/volumes/root_aead.go
+++ b/src/internal/volumes/root_aead.go
@@ -79,17 +79,21 @@ func (tx *RootAEADTx) Volume() Volume {
 	return tx.vol
 }
 
-func (tx *RootAEADTx) Commit(ctx context.Context, ptext []byte) error {
+func (tx *RootAEADTx) Commit(ctx context.Context) error {
+	return tx.inner.Commit(ctx)
+}
+
+func (tx *RootAEADTx) Abort(ctx context.Context) error {
+	return tx.inner.Abort(ctx)
+}
+
+func (tx *RootAEADTx) Save(ctx context.Context, ptext []byte) error {
 	nonce := make([]byte, tx.aead.NonceSize())
 	if _, err := rand.Read(nonce); err != nil {
 		panic(err)
 	}
 	ctext := tx.aead.Seal(nonce, nonce, ptext, nil)
-	return tx.inner.Commit(ctx, ctext)
-}
-
-func (tx *RootAEADTx) Abort(ctx context.Context) error {
-	return tx.inner.Abort(ctx)
+	return tx.inner.Save(ctx, ctext)
 }
 
 func (tx *RootAEADTx) Load(ctx context.Context, dst *[]byte) error {

--- a/src/internal/volumes/volume.go
+++ b/src/internal/volumes/volume.go
@@ -15,9 +15,10 @@ type Volume interface {
 
 // Tx is a consistent view of a volume, during a transaction.
 type Tx interface {
-	Commit(ctx context.Context, root []byte) error
+	Commit(ctx context.Context) error
 	Abort(ctx context.Context) error
 
+	Save(ctx context.Context, src []byte) error
 	Load(ctx context.Context, dst *[]byte) error
 
 	Post(ctx context.Context, salt *blobcache.CID, data []byte) (blobcache.CID, error)

--- a/src/schema/glfs/glfs.go
+++ b/src/schema/glfs/glfs.go
@@ -109,5 +109,8 @@ func SyncTx(ctx context.Context, srcTx, dstTx *blobcache.Tx) error {
 	if err := glfs.Sync(ctx, dstTx, srcTx, *srcRoot); err != nil {
 		return err
 	}
-	return dstTx.Commit(ctx, MarshalRef(srcRoot))
+	if err := dstTx.Save(ctx, MarshalRef(srcRoot)); err != nil {
+		return err
+	}
+	return dstTx.Commit(ctx)
 }

--- a/src/schema/simplecont/simplecont.go
+++ b/src/schema/simplecont/simplecont.go
@@ -30,7 +30,7 @@ func (sch Schema) Validate(ctx context.Context, s cadata.Getter, prevRoot, nextR
 }
 
 func (sch Schema) WalkOIDs(ctx context.Context, s cadata.Getter, cid blobcache.CID, fn func(blobcache.OID) error) error {
-	buf := make([]byte, blobcache.CIDBytes*2)
+	buf := make([]byte, blobcache.CIDSize*2)
 	n, err := s.Get(ctx, cid, buf)
 	if err != nil {
 		return err
@@ -38,10 +38,10 @@ func (sch Schema) WalkOIDs(ctx context.Context, s cadata.Getter, cid blobcache.C
 	switch n {
 	case 16:
 		return nil // base case, this is a Volume's OID
-	case 2 * blobcache.CIDBytes:
+	case 2 * blobcache.CIDSize:
 		// this is a Merkle tree node, so we need to validate the children
-		left := cadata.IDFromBytes(buf[:blobcache.CIDBytes])
-		right := cadata.IDFromBytes(buf[blobcache.CIDBytes:])
+		left := cadata.IDFromBytes(buf[:blobcache.CIDSize])
+		right := cadata.IDFromBytes(buf[blobcache.CIDSize:])
 		for _, cid2 := range []cadata.ID{left, right} {
 			if err := sch.WalkOIDs(ctx, s, cid2, fn); err != nil {
 				return err

--- a/src/schema/simplens/simplens.go
+++ b/src/schema/simplens/simplens.go
@@ -46,8 +46,8 @@ func (sch Schema) ListEntries(ctx context.Context, s cadata.Getter, root []byte)
 	if len(root) == 0 {
 		return nil, nil
 	}
-	if len(root) != blobcache.CIDBytes {
-		return nil, fmt.Errorf("root must be %d bytes. HAVE: %d", blobcache.CIDBytes, len(root))
+	if len(root) != blobcache.CIDSize {
+		return nil, fmt.Errorf("root must be %d bytes. HAVE: %d", blobcache.CIDSize, len(root))
 	}
 	cid := cadata.IDFromBytes(root)
 	buf := make([]byte, s.MaxSize())
@@ -167,7 +167,10 @@ func (ns Tx) ListNames(ctx context.Context) ([]string, error) {
 }
 
 func (ns Tx) Commit(ctx context.Context) error {
-	return ns.Tx.Commit(ctx, ns.Root)
+	if err := ns.Tx.Save(ctx, ns.Root); err != nil {
+		return err
+	}
+	return ns.Tx.Commit(ctx)
 }
 
 func encodeNamespace(ents []Entry) ([]byte, error) {


### PR DESCRIPTION
Adds `Save(ctx context.Context, txh Handle, data []byte) error` to `blobcache.Service`.
Commit no longer takes root data as an argument.