### PR TITLE
bcnet: Use binary encoding

### DIFF
--- a/src/bchttp/bchttp.go
+++ b/src/bchttp/bchttp.go
@@ -3,7 +3,6 @@ package bchttp
 
 import (
 	"blobcache.io/blobcache/src/blobcache"
-	"blobcache.io/blobcache/src/internal/bcnet"
 )
 
 // Handle messages.
@@ -27,10 +26,11 @@ type KeepAliveReq struct {
 
 type KeepAliveResp struct{}
 
-type (
-	AwaitReq  = bcnet.AwaitReq
-	AwaitResp = bcnet.AwaitResp
-)
+type AwaitReq struct {
+	Cond blobcache.Conditions `json:"cond"`
+}
+
+type AwaitResp struct{}
 
 type OpenFromReq struct {
 	Base   blobcache.Handle    `json:"base"`

--- a/src/bchttp/bchttp.go
+++ b/src/bchttp/bchttp.go
@@ -7,29 +7,55 @@ import (
 )
 
 // Handle messages.
-type (
-	InspectHandleReq  = bcnet.InspectHandleReq
-	InspectHandleResp = bcnet.InspectHandleResp
-	DropReq           = bcnet.DropReq
-	DropResp          = bcnet.DropResp
-	KeepAliveReq      = bcnet.KeepAliveReq
-	KeepAliveResp     = bcnet.KeepAliveResp
-	OpenFromReq       = bcnet.OpenFromReq
-	OpenFromResp      = bcnet.OpenFromResp
-	OpenAsResp        = bcnet.OpenAsResp
-)
+type InspectHandleReq struct {
+	Handle blobcache.Handle `json:"handle"`
+}
 
-// Volume messages.
+type InspectHandleResp struct {
+	Info blobcache.HandleInfo `json:"info"`
+}
+
+type DropReq struct {
+	Handle blobcache.Handle `json:"handle"`
+}
+
+type DropResp struct{}
+
+type KeepAliveReq struct {
+	Handles []blobcache.Handle `json:"handles"`
+}
+
+type KeepAliveResp struct{}
 
 type (
 	AwaitReq  = bcnet.AwaitReq
 	AwaitResp = bcnet.AwaitResp
 )
 
+type OpenFromReq struct {
+	Base   blobcache.Handle    `json:"base"`
+	Target blobcache.OID       `json:"target"`
+	Mask   blobcache.ActionSet `json:"mask"`
+}
+
+type OpenFromResp struct {
+	Handle blobcache.Handle     `json:"handle"`
+	Info   blobcache.VolumeInfo `json:"info"`
+}
+
 type OpenAsReq struct {
 	Caller *blobcache.PeerID   `json:"caller,omitempty"`
 	Target blobcache.OID       `json:"target"`
 	Mask   blobcache.ActionSet `json:"mask"`
+}
+
+type OpenAsResp struct {
+	Handle blobcache.Handle     `json:"handle"`
+	Info   blobcache.VolumeInfo `json:"info"`
+}
+
+type InspectVolumeReq struct {
+	Volume blobcache.Handle `json:"volume"`
 }
 
 type CreateVolumeReq struct {

--- a/src/bclocal/bclocal.go
+++ b/src/bclocal/bclocal.go
@@ -408,8 +408,8 @@ func (s *Service) InspectHandle(ctx context.Context, h blobcache.Handle) (*blobc
 	}
 	return &blobcache.HandleInfo{
 		OID:       h.OID,
-		CreatedAt: tai64.Now(), // TODO: store creation time.
-		ExpiresAt: tai64.FromGoTime(hstate.expiresAt),
+		CreatedAt: tai64.Now().TAI64(), // TODO: store creation time.
+		ExpiresAt: tai64.FromGoTime(hstate.expiresAt).TAI64(),
 	}, nil
 }
 

--- a/src/blobcache/blobcache.go
+++ b/src/blobcache/blobcache.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha3"
 	"database/sql/driver"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -176,6 +177,18 @@ type Conditions struct {
 	NOTEqual *NOTEqual `json:"not,omitempty"`
 }
 
+func (c Conditions) Marshal(out []byte) []byte {
+	data, err := json.Marshal(c)
+	if err != nil {
+		panic(err)
+	}
+	return append(out, data...)
+}
+
+func (c *Conditions) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, c)
+}
+
 type NOTEqual struct {
 	Volume Handle
 	Value  []byte
@@ -187,11 +200,35 @@ type TxParams struct {
 	Mutate bool
 }
 
+func (tp TxParams) Marshal(out []byte) []byte {
+	data, err := json.Marshal(tp)
+	if err != nil {
+		panic(err)
+	}
+	return append(out, data...)
+}
+
+func (tp *TxParams) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, tp)
+}
+
 type TxInfo struct {
 	ID       OID
 	Volume   OID
 	MaxSize  int64
 	HashAlgo HashAlgo
+}
+
+func (ti TxInfo) Marshal(out []byte) []byte {
+	data, err := json.Marshal(ti)
+	if err != nil {
+		panic(err)
+	}
+	return append(out, data...)
+}
+
+func (ti *TxInfo) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, ti)
 }
 
 type Service interface {

--- a/src/blobcache/blobcache.go
+++ b/src/blobcache/blobcache.go
@@ -108,11 +108,26 @@ func (h HashAlgo) HashFunc() HashFunc {
 	}
 }
 
+// OIDSize is the number of bytes in an OID.
+const OIDSize = 16
+
 // OID is an object identifier.
-type OID [16]byte
+type OID [OIDSize]byte
 
 func (o OID) Compare(other OID) int {
 	return bytes.Compare(o[:], other[:])
+}
+
+func (o OID) Marshal(out []byte) []byte {
+	return append(out, o[:]...)
+}
+
+func (o *OID) Unmarshal(data []byte) error {
+	if len(data) < OIDSize {
+		return fmt.Errorf("OID: data too short: %d", len(data))
+	}
+	copy(o[:], data)
+	return nil
 }
 
 func NewOID() (ret OID) {

--- a/src/blobcache/blobcache_test.go
+++ b/src/blobcache/blobcache_test.go
@@ -1,0 +1,50 @@
+package blobcache
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshal(t *testing.T) {
+	t.Run("OID", func(t *testing.T) {
+		tcs := []OID{
+			{},
+		}
+		for i, tc := range tcs {
+			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+				x := tc
+				data := x.Marshal(nil)
+				var y OID
+				require.NoError(t, y.Unmarshal(data))
+			})
+		}
+	})
+	t.Run("HandleInfo", func(t *testing.T) {
+		tcs := []HandleInfo{
+			{},
+		}
+		for i, tc := range tcs {
+			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+				x := tc
+				data := x.Marshal(nil)
+				var y HandleInfo
+				require.NoError(t, y.Unmarshal(data))
+			})
+		}
+	})
+	t.Run("Handle", func(t *testing.T) {
+		tcs := []Handle{
+			{},
+		}
+		for i, tc := range tcs {
+			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+				x := tc
+				data := x.Marshal(nil)
+				var y Handle
+				require.NoError(t, y.Unmarshal(data))
+			})
+		}
+	})
+}

--- a/src/blobcache/volume.go
+++ b/src/blobcache/volume.go
@@ -1,6 +1,7 @@
 package blobcache
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"iter"
@@ -38,6 +39,18 @@ type VolumeInfo struct {
 	Backend VolumeBackend[OID] `json:"backend"`
 }
 
+func (vi VolumeInfo) Marshal(out []byte) []byte {
+	data, err := json.Marshal(vi)
+	if err != nil {
+		panic(err)
+	}
+	return append(out, data...)
+}
+
+func (vi *VolumeInfo) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, vi)
+}
+
 // VolumeBackend is a specification for a volume backend.
 // If it is going into the API, the it will be a VolumeBackend[Handle].
 // If it is coming out of the API, the it will be a VolumeBackend[OID].
@@ -47,6 +60,18 @@ type VolumeBackend[T handleOrOID] struct {
 	Git      *VolumeBackend_Git         `json:"git,omitempty"`
 	RootAEAD *VolumeBackend_RootAEAD[T] `json:"root_aead,omitempty"`
 	Vault    *VolumeBackend_Vault[T]    `json:"vault,omitempty"`
+}
+
+func (v *VolumeBackend[T]) Marshal(out []byte) []byte {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return append(out, data...)
+}
+
+func (v *VolumeBackend[T]) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, v)
 }
 
 // Deps returns the volumes which must exist before this volume can be created.

--- a/src/internal/bcnet/message.go
+++ b/src/internal/bcnet/message.go
@@ -162,9 +162,10 @@ func (m *Message) SetError(err error) {
 		m.SetCode(MT_ERROR_NO_LINK)
 	default:
 		m.SetCode(MT_ERROR_UNKNOWN)
+		m.SetBody([]byte(err.Error()))
+		return
 	}
-	data := jsonMarshal(err)
-	m.SetBody(data)
+	m.SetBody(jsonMarshal(err))
 }
 
 func ParseWireError(code MessageType, x []byte) error {

--- a/src/internal/bcnet/server.go
+++ b/src/internal/bcnet/server.go
@@ -36,7 +36,7 @@ func (s *Server) serve(ctx context.Context, ep blobcache.Endpoint, req *Message,
 			return &DropResp{}, nil
 		})
 	case MT_HANDLE_INSPECT:
-		handleJSON(req, resp, func(req *InspectHandleReq) (*InspectHandleResp, error) {
+		handleAsk(req, resp, &InspectHandleReq{}, func(req *InspectHandleReq) (*InspectHandleResp, error) {
 			info, err := svc.InspectHandle(ctx, req.Handle)
 			if err != nil {
 				return nil, err

--- a/src/internal/bcnet/volume.go
+++ b/src/internal/bcnet/volume.go
@@ -107,7 +107,7 @@ func (tx *Tx) Commit(ctx context.Context) error {
 	}
 	_, err := doJSON[CommitReq, CommitResp](ctx, tx.n, tx.ep, MT_TX_COMMIT, CommitReq{
 		Tx:   tx.h,
-		Root: root,
+		Root: &root,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Use binary encodings in bcnet package.
All transaction and handle methods use binary encoding.
Some of the Volume methods fallback on encoding defined in the blobcache package for VolumeInfo.  This is currently JSON, but may change.
The bcnet package does not introduce any new uses of JSON.