### PR TITLE
CreateVolume host parameter

### DIFF
--- a/src/bchttp/bchttp.go
+++ b/src/bchttp/bchttp.go
@@ -44,7 +44,6 @@ type OpenFromResp struct {
 }
 
 type OpenAsReq struct {
-	Caller *blobcache.PeerID   `json:"caller,omitempty"`
 	Target blobcache.OID       `json:"target"`
 	Mask   blobcache.ActionSet `json:"mask"`
 }
@@ -59,8 +58,8 @@ type InspectVolumeReq struct {
 }
 
 type CreateVolumeReq struct {
-	Caller *blobcache.PeerID    `json:"caller,omitempty"`
-	Spec   blobcache.VolumeSpec `json:"spec"`
+	Host *blobcache.Endpoint  `json:"host,omitempty"`
+	Spec blobcache.VolumeSpec `json:"spec"`
 }
 
 type CreateVolumeResp struct {

--- a/src/bchttp/client.go
+++ b/src/bchttp/client.go
@@ -58,8 +58,8 @@ func (c *Client) KeepAlive(ctx context.Context, hs []blobcache.Handle) error {
 	return c.doJSON(ctx, "POST", "/KeepAlive", nil, req, &resp)
 }
 
-func (c *Client) OpenAs(ctx context.Context, caller *blobcache.PeerID, target blobcache.OID, mask blobcache.ActionSet) (*blobcache.Handle, error) {
-	req := OpenAsReq{Caller: caller, Target: target, Mask: mask}
+func (c *Client) OpenAs(ctx context.Context, target blobcache.OID, mask blobcache.ActionSet) (*blobcache.Handle, error) {
+	req := OpenAsReq{Target: target, Mask: mask}
 	var resp OpenAsResp
 	if err := c.doJSON(ctx, "POST", "/OpenAs", nil, req, &resp); err != nil {
 		return nil, err
@@ -76,8 +76,8 @@ func (c *Client) OpenFrom(ctx context.Context, base blobcache.Handle, target blo
 	return &resp.Handle, nil
 }
 
-func (c *Client) CreateVolume(ctx context.Context, caller *blobcache.PeerID, vspec blobcache.VolumeSpec) (*blobcache.Handle, error) {
-	req := CreateVolumeReq{Caller: caller, Spec: vspec}
+func (c *Client) CreateVolume(ctx context.Context, host *blobcache.Endpoint, vspec blobcache.VolumeSpec) (*blobcache.Handle, error) {
+	req := CreateVolumeReq{Host: host, Spec: vspec}
 	var resp CreateVolumeResp
 	if err := c.doJSON(ctx, "POST", "/volume/", nil, req, &resp); err != nil {
 		return nil, err

--- a/src/bchttp/server.go
+++ b/src/bchttp/server.go
@@ -36,7 +36,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		})
 	case r.URL.Path == "/OpenAs":
 		handleRequest(w, r, func(ctx context.Context, req OpenAsReq) (*OpenAsResp, error) {
-			handle, err := s.Service.OpenAs(ctx, req.Caller, req.Target, req.Mask)
+			handle, err := s.Service.OpenAs(ctx, req.Target, req.Mask)
 			if err != nil {
 				return nil, err
 			}
@@ -91,7 +91,7 @@ func (s *Server) handleVolume(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case r.URL.Path == "/volume/":
 		handleRequest(w, r, func(ctx context.Context, req CreateVolumeReq) (*CreateVolumeResp, error) {
-			vol, err := s.Service.CreateVolume(ctx, req.Caller, req.Spec)
+			vol, err := s.Service.CreateVolume(ctx, req.Host, req.Spec)
 			if err != nil {
 				return nil, err
 			}

--- a/src/bclocal/local_volume.go
+++ b/src/bclocal/local_volume.go
@@ -757,7 +757,7 @@ func (ltx *localTxnMut) Commit(ctx context.Context) error {
 		//nolint:copylocks // see above
 		ltx2 := *ltx
 		ltx2.mu = sync.RWMutex{}
-		var store cadata.Getter = volumes.NewUnsaltedStore(&ltx2)
+		var store schema.RO = volumes.NewUnsaltedStore(&ltx2)
 		if err := contSch.ReadLinks(ctx, store, root, links); err != nil {
 			return err
 		}

--- a/src/bclocal/peerview.go
+++ b/src/bclocal/peerview.go
@@ -1,0 +1,42 @@
+package bclocal
+
+import (
+	"context"
+	"fmt"
+
+	"blobcache.io/blobcache/src/blobcache"
+)
+
+var _ blobcache.Service = &peerView{}
+
+type peerView struct {
+	*Service
+	Caller blobcache.PeerID
+}
+
+func (pv *peerView) CreateVolume(ctx context.Context, host *blobcache.Endpoint, vspec blobcache.VolumeSpec) (*blobcache.Handle, error) {
+	pol := pv.Service.env.Policy
+	if !pol.CanCreate(pv.Caller) {
+		return nil, ErrNotAllowed{
+			Peer:   pv.Caller,
+			Action: "CreateVolume",
+		}
+	}
+	if host != nil {
+		return nil, fmt.Errorf("peers cannot ask us to create volumes on remote nodes")
+	}
+	return pv.Service.CreateVolume(ctx, nil, vspec)
+}
+
+func (pv *peerView) OpenAs(ctx context.Context, x blobcache.OID, mask blobcache.ActionSet) (*blobcache.Handle, error) {
+	pol := pv.Service.env.Policy
+	if rights := pol.Open(pv.Caller, x); rights == 0 {
+		return nil, ErrNotAllowed{
+			Peer:   pv.Caller,
+			Action: "OpenAs",
+			Target: x,
+		}
+	} else {
+		return pv.Service.OpenAs(ctx, x, rights&mask)
+	}
+}

--- a/src/bcremote/bcremote.go
+++ b/src/bcremote/bcremote.go
@@ -89,8 +89,8 @@ func (s *Service) InspectHandle(ctx context.Context, h blobcache.Handle) (*blobc
 	return bcnet.InspectHandle(ctx, s.node, s.ep, h)
 }
 
-func (s *Service) OpenAs(ctx context.Context, caller *blobcache.PeerID, target blobcache.OID, mask blobcache.ActionSet) (*blobcache.Handle, error) {
-	return bcnet.OpenAs(ctx, s.node, s.ep, caller, target, mask)
+func (s *Service) OpenAs(ctx context.Context, target blobcache.OID, mask blobcache.ActionSet) (*blobcache.Handle, error) {
+	return bcnet.OpenAs(ctx, s.node, s.ep, target, mask)
 }
 
 func (s *Service) OpenFrom(ctx context.Context, base blobcache.Handle, target blobcache.OID, mask blobcache.ActionSet) (*blobcache.Handle, error) {
@@ -106,11 +106,11 @@ func (s *Service) BeginTx(ctx context.Context, volh blobcache.Handle, txp blobca
 }
 
 // CreateVolume creates a new volume.
-func (s *Service) CreateVolume(ctx context.Context, caller *blobcache.PeerID, vspec blobcache.VolumeSpec) (*blobcache.Handle, error) {
-	if caller != nil && *caller != s.node.LocalID() {
+func (s *Service) CreateVolume(ctx context.Context, host *blobcache.Endpoint, vspec blobcache.VolumeSpec) (*blobcache.Handle, error) {
+	if host != nil && *host != s.ep {
 		return nil, fmt.Errorf("bcremote: caller cannot be different from the node ID")
 	}
-	return bcnet.CreateVolume(ctx, s.node, s.ep, caller, vspec)
+	return bcnet.CreateVolume(ctx, s.node, s.ep, vspec)
 }
 
 // InspectVolume returns info about a Volume.

--- a/src/blobcache/algo.go
+++ b/src/blobcache/algo.go
@@ -1,0 +1,118 @@
+package blobcache
+
+import (
+	"crypto/sha256"
+	"crypto/sha3"
+	"fmt"
+
+	"golang.org/x/crypto/blake2b"
+	"lukechampine.com/blake3"
+)
+
+// HashFunc is a cryptographic hash function.
+type HashFunc func(salt *CID, data []byte) CID
+
+// HashAlgo is a cryptographic hash algorithm.
+type HashAlgo string
+
+const (
+	HashAlgo_BLAKE3_256  HashAlgo = "blake3-256"
+	HashAlgo_BLAKE2b_256 HashAlgo = "blake2b-256"
+	HashAlgo_SHA2_256    HashAlgo = "sha2-256"
+	HashAlgo_SHA3_256    HashAlgo = "sha3-256"
+	HashAlgo_CSHAKE256   HashAlgo = "cshake256"
+)
+
+func (h HashAlgo) Validate() error {
+	switch h {
+	case HashAlgo_BLAKE3_256, HashAlgo_BLAKE2b_256:
+		fallthrough
+	case HashAlgo_SHA2_256:
+		fallthrough
+	case HashAlgo_SHA3_256, HashAlgo_CSHAKE256:
+		return nil
+	}
+	return fmt.Errorf("unknown hash algo: %q", h)
+}
+
+func (h HashAlgo) HashFunc() HashFunc {
+	switch h {
+	case HashAlgo_SHA2_256:
+		return func(salt *CID, x []byte) CID {
+			if salt != nil {
+				panic("salt not supported for sha2-256")
+			}
+			return sha256.Sum256(x)
+		}
+	case HashAlgo_SHA3_256:
+		return func(salt *CID, x []byte) CID {
+			if salt == nil {
+				return sha3.Sum256(x)
+			}
+			h := sha3.NewCSHAKE256(nil, salt[:])
+			h.Write(x)
+			var ret CID
+			if _, err := h.Read(ret[:]); err != nil {
+				panic(err)
+			}
+			return ret
+		}
+	case HashAlgo_CSHAKE256:
+		return func(salt *CID, x []byte) CID {
+			if salt == nil {
+				return CID(sha3.SumSHAKE256(x, 32))
+			} else {
+				h := sha3.NewCSHAKE256(nil, salt[:])
+				h.Write(x)
+				var ret CID
+				if _, err := h.Read(ret[:]); err != nil {
+					panic(err)
+				}
+				return ret
+			}
+		}
+	case HashAlgo_BLAKE2b_256:
+		return func(salt *CID, x []byte) CID {
+			if salt == nil {
+				return blake2b.Sum256(x)
+			}
+			h, err := blake2b.New(32, salt[:])
+			if err != nil {
+				panic(err)
+			}
+			h.Write(x)
+			var ret CID
+			copy(ret[:], h.Sum(nil))
+			return ret
+		}
+	case HashAlgo_BLAKE3_256:
+		return func(salt *CID, x []byte) CID {
+			if salt == nil {
+				return blake3.Sum256(x)
+			}
+			h := blake3.New(32, salt[:])
+			h.Write(x)
+			var ret CID
+			copy(ret[:], h.Sum(nil))
+			return ret
+		}
+	default:
+		panic(h)
+	}
+}
+
+// AEADAlgo is an algorithm for Authenticated Encryption with Associated Data (AEAD).
+type AEADAlgo string
+
+const (
+	AEAD_CHACHA20POLY1305 AEADAlgo = "chacha20poly1305"
+)
+
+func (a AEADAlgo) Validate() error {
+	switch a {
+	case AEAD_CHACHA20POLY1305:
+	default:
+		return fmt.Errorf("unknown aead algo: %s", a)
+	}
+	return nil
+}

--- a/src/blobcache/blobcachetests/basicns.go
+++ b/src/blobcache/blobcachetests/basicns.go
@@ -68,7 +68,7 @@ func BasicNS(t *testing.T, mk func(t testing.TB) blobcache.Service) {
 		require.NoError(t, err)
 		require.NotNil(t, volh)
 		nsc := basicns.Client{Service: s}
-		nsh, err := s.OpenAs(ctx, nil, blobcache.OID{}, blobcache.Action_ALL)
+		nsh, err := s.OpenAs(ctx, blobcache.OID{}, blobcache.Action_ALL)
 		require.NoError(t, err)
 		err = nsc.PutEntry(ctx, *nsh, "test-name", *volh)
 		require.NoError(t, err)
@@ -88,7 +88,7 @@ func BasicNS(t *testing.T, mk func(t testing.TB) blobcache.Service) {
 		volh, err := s.CreateVolume(ctx, nil, defaultLocalSpec())
 		require.NoError(t, err)
 		require.NotNil(t, volh)
-		nsh, err := s.OpenAs(ctx, nil, blobcache.OID{}, blobcache.Action_ALL)
+		nsh, err := s.OpenAs(ctx, blobcache.OID{}, blobcache.Action_ALL)
 		require.NoError(t, err)
 		nsc := basicns.Client{Service: s}
 		// Delets are idempotent, should not get an error.
@@ -105,7 +105,7 @@ func BasicNS(t *testing.T, mk func(t testing.TB) blobcache.Service) {
 		nsc := basicns.Client{Service: s}
 		require.NoError(t, nsc.PutEntry(ctx, blobcache.Handle{}, "vol1", *volh))
 
-		nsh, err := s.OpenAs(ctx, nil, blobcache.OID{}, blobcache.Action_ALL)
+		nsh, err := s.OpenAs(ctx, blobcache.OID{}, blobcache.Action_ALL)
 		require.NoError(t, err)
 		txh, err := s.BeginTx(ctx, *nsh, blobcache.TxParams{Mutate: true})
 		require.NoError(t, err)
@@ -120,7 +120,7 @@ func BasicNS(t *testing.T, mk func(t testing.TB) blobcache.Service) {
 		s := mk(t)
 		// Open the root namespace
 		nsc := basicns.Client{Service: s}
-		rootNSh, err := s.OpenAs(ctx, nil, blobcache.OID{}, blobcache.Action_ALL)
+		rootNSh, err := s.OpenAs(ctx, blobcache.OID{}, blobcache.Action_ALL)
 		require.NoError(t, err)
 
 		// Create 10 nested namespaces.
@@ -146,7 +146,7 @@ func BasicNS(t *testing.T, mk func(t testing.TB) blobcache.Service) {
 		ctx := testutil.Context(t)
 		s := mk(t)
 		nsc := basicns.Client{Service: s}
-		rootNSh, err := s.OpenAs(ctx, nil, blobcache.OID{}, blobcache.Action_ALL)
+		rootNSh, err := s.OpenAs(ctx, blobcache.OID{}, blobcache.Action_ALL)
 		require.NoError(t, err)
 
 		for i := 0; i < 10; i++ {

--- a/src/blobcache/blobcachetests/multinode.go
+++ b/src/blobcache/blobcachetests/multinode.go
@@ -19,7 +19,7 @@ func TestMultiNode(t *testing.T, mk func(t testing.TB, n int) []blobcache.Servic
 		// create a volume on the first node
 		volh, err := s1.CreateVolume(ctx, nil, defaultLocalSpec())
 		require.NoError(t, err)
-		nsh, err := s1.OpenAs(ctx, nil, blobcache.OID{}, blobcache.Action_ALL)
+		nsh, err := s1.OpenAs(ctx, blobcache.OID{}, blobcache.Action_ALL)
 		require.NoError(t, err)
 		nsc := basicns.Client{Service: s1}
 		require.NoError(t, nsc.PutEntry(ctx, *nsh, "name1", *volh))

--- a/src/blobcache/blobcachetests/service.go
+++ b/src/blobcache/blobcachetests/service.go
@@ -54,6 +54,7 @@ func ServiceAPI(t *testing.T, mk func(t testing.TB) blobcache.Service) {
 			blobcache.HashAlgo_BLAKE2b_256,
 			blobcache.HashAlgo_SHA2_256,
 			blobcache.HashAlgo_SHA3_256,
+			blobcache.HashAlgo_CSHAKE256,
 		} {
 			t.Run(string(algo), func(t *testing.T) {
 				spec := defaultLocalSpec()

--- a/src/blobcache/blobcachetests/util.go
+++ b/src/blobcache/blobcachetests/util.go
@@ -12,9 +12,9 @@ func defaultLocalSpec() blobcache.VolumeSpec {
 	return blobcache.DefaultLocalSpec()
 }
 
-func CreateVolume(t testing.TB, s blobcache.Service, caller *blobcache.PeerID, spec blobcache.VolumeSpec) blobcache.Handle {
+func CreateVolume(t testing.TB, s blobcache.Service, host *blobcache.Endpoint, spec blobcache.VolumeSpec) blobcache.Handle {
 	ctx := testutil.Context(t)
-	volh, err := s.CreateVolume(ctx, caller, spec)
+	volh, err := s.CreateVolume(ctx, host, spec)
 	require.NoError(t, err)
 	require.NotNil(t, volh)
 	return *volh

--- a/src/blobcache/schema.go
+++ b/src/blobcache/schema.go
@@ -1,0 +1,1 @@
+package blobcache

--- a/src/blobcache/volume.go
+++ b/src/blobcache/volume.go
@@ -239,21 +239,6 @@ func DefaultLocalSpec() VolumeSpec {
 	}
 }
 
-type AEADAlgo string
-
-const (
-	AEAD_CHACHA20POLY1305 AEADAlgo = "chacha20poly1305"
-)
-
-func (a AEADAlgo) Validate() error {
-	switch a {
-	case AEAD_CHACHA20POLY1305:
-	default:
-		return fmt.Errorf("unknown aead algo: %s", a)
-	}
-	return nil
-}
-
 func emptyIter[T any]() iter.Seq[T] {
 	return func(yield func(T) bool) {}
 }

--- a/src/internal/bcnet/rpc.go
+++ b/src/internal/bcnet/rpc.go
@@ -36,7 +36,7 @@ func InspectHandle(ctx context.Context, tp Transport, ep blobcache.Endpoint, h b
 	return &resp.Info, nil
 }
 
-func OpenAs(ctx context.Context, tp Transport, ep blobcache.Endpoint, caller *blobcache.PeerID, target blobcache.OID, mask blobcache.ActionSet) (*blobcache.Handle, error) {
+func OpenAs(ctx context.Context, tp Transport, ep blobcache.Endpoint, target blobcache.OID, mask blobcache.ActionSet) (*blobcache.Handle, error) {
 	var resp OpenAsResp
 	if _, err := doAsk(ctx, tp, ep, MT_OPEN_AS, OpenAsReq{Target: target, Mask: mask}, &resp); err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func Await(ctx context.Context, tp Transport, ep blobcache.Endpoint, cond blobca
 	return nil
 }
 
-func CreateVolume(ctx context.Context, tp Transport, ep blobcache.Endpoint, caller *blobcache.PeerID, vspec blobcache.VolumeSpec) (*blobcache.Handle, error) {
+func CreateVolume(ctx context.Context, tp Transport, ep blobcache.Endpoint, vspec blobcache.VolumeSpec) (*blobcache.Handle, error) {
 	var resp CreateVolumeResp
 	if _, err := doAsk(ctx, tp, ep, MT_CREATE_VOLUME, CreateVolumeReq{Spec: vspec}, &resp); err != nil {
 		return nil, err

--- a/src/internal/bcnet/server.go
+++ b/src/internal/bcnet/server.go
@@ -54,7 +54,7 @@ func (s *Server) serve(ctx context.Context, ep blobcache.Endpoint, req *Message,
 	// BEGIN VOLUME
 	case MT_OPEN_AS:
 		handleAsk(req, resp, &OpenAsReq{}, func(req *OpenAsReq) (*OpenAsResp, error) {
-			h, err := svc.OpenAs(ctx, &ep.Peer, req.Target, req.Mask)
+			h, err := svc.OpenAs(ctx, req.Target, req.Mask)
 			if err != nil {
 				return nil, err
 			}
@@ -78,7 +78,7 @@ func (s *Server) serve(ctx context.Context, ep blobcache.Endpoint, req *Message,
 		})
 	case MT_CREATE_VOLUME:
 		handleAsk(req, resp, &CreateVolumeReq{}, func(req *CreateVolumeReq) (*CreateVolumeResp, error) {
-			h, err := svc.CreateVolume(ctx, &ep.Peer, req.Spec)
+			h, err := svc.CreateVolume(ctx, nil, req.Spec)
 			if err != nil {
 				return nil, err
 			}

--- a/src/internal/tries/builder.go
+++ b/src/internal/tries/builder.go
@@ -10,8 +10,6 @@ import (
 type writeStore interface {
 	Post(ctx context.Context, data []byte) (blobcache.CID, error)
 	Get(ctx context.Context, cid blobcache.CID, buf []byte) (int, error)
-	Delete(ctx context.Context, cid blobcache.CID) error
-	Exists(ctx context.Context, cid blobcache.CID) (bool, error)
 	MaxSize() int
 	Hash(data []byte) blobcache.CID
 }

--- a/src/internal/tries/operator.go
+++ b/src/internal/tries/operator.go
@@ -61,7 +61,7 @@ func (o *Machine) Get(ctx context.Context, s cadata.Getter, root Root, key []byt
 }
 
 // Put returns a copy of root where key maps to value, and all other mappings are unchanged.
-func (o *Machine) Put(ctx context.Context, s cadata.Store, root Root, key, value []byte) (*Root, error) {
+func (o *Machine) Put(ctx context.Context, s writeStore, root Root, key, value []byte) (*Root, error) {
 	e := &Entry{Key: key, Value: value}
 	return o.PutBatch(ctx, s, root, []*Entry{e})
 }

--- a/src/internal/volumes/volume.go
+++ b/src/internal/volumes/volume.go
@@ -67,16 +67,15 @@ func (v UnsaltedStore) Get(ctx context.Context, cid blobcache.CID, buf []byte) (
 	return v.inner.Get(ctx, cid, buf, blobcache.GetOpts{})
 }
 
-func (v UnsaltedStore) Delete(ctx context.Context, cid blobcache.CID) error {
-	return v.inner.Delete(ctx, []blobcache.CID{cid})
+func (v UnsaltedStore) Delete(ctx context.Context, cids []blobcache.CID) error {
+	return v.inner.Delete(ctx, cids)
 }
 
-func (v UnsaltedStore) Exists(ctx context.Context, cid blobcache.CID) (bool, error) {
-	dst := [1]bool{}
-	if err := v.inner.Exists(ctx, []blobcache.CID{cid}, dst[:]); err != nil {
-		return false, err
+func (v UnsaltedStore) Exists(ctx context.Context, cids []blobcache.CID, dst []bool) error {
+	if err := v.inner.Exists(ctx, cids, dst[:]); err != nil {
+		return err
 	}
-	return dst[0], nil
+	return nil
 }
 
 func (v UnsaltedStore) MaxSize() int {

--- a/src/schema/basiccont/basiccont.go
+++ b/src/schema/basiccont/basiccont.go
@@ -18,7 +18,7 @@ var (
 // Schema
 type Schema struct{}
 
-func (sch Schema) Validate(ctx context.Context, s cadata.Getter, prevRoot, nextRoot []byte) error {
+func (sch Schema) Validate(ctx context.Context, s schema.RO, prevRoot, nextRoot []byte) error {
 	var prev blobcache.OID
 	return sch.WalkOIDs(ctx, s, cadata.IDFromBytes(nextRoot), func(oid blobcache.OID) error {
 		if oid.Compare(prev) < 0 {
@@ -29,7 +29,7 @@ func (sch Schema) Validate(ctx context.Context, s cadata.Getter, prevRoot, nextR
 	})
 }
 
-func (sch Schema) WalkOIDs(ctx context.Context, s cadata.Getter, cid blobcache.CID, fn func(blobcache.OID) error) error {
+func (sch Schema) WalkOIDs(ctx context.Context, s schema.RO, cid blobcache.CID, fn func(blobcache.OID) error) error {
 	buf := make([]byte, blobcache.CIDSize*2)
 	n, err := s.Get(ctx, cid, buf)
 	if err != nil {
@@ -53,7 +53,7 @@ func (sch Schema) WalkOIDs(ctx context.Context, s cadata.Getter, cid blobcache.C
 	}
 }
 
-func (sch Schema) ListOIDs(ctx context.Context, s cadata.Getter, root []byte) ([]blobcache.OID, error) {
+func (sch Schema) ListOIDs(ctx context.Context, s schema.RO, root []byte) ([]blobcache.OID, error) {
 	var ret []blobcache.OID
 	err := sch.WalkOIDs(ctx, s, cadata.IDFromBytes(root), func(oid blobcache.OID) error {
 		ret = append(ret, oid)
@@ -62,7 +62,7 @@ func (sch Schema) ListOIDs(ctx context.Context, s cadata.Getter, root []byte) ([
 	return ret, err
 }
 
-func (sch Schema) ReadLinks(ctx context.Context, s cadata.Getter, root []byte, dst map[blobcache.OID]blobcache.ActionSet) error {
+func (sch Schema) ReadLinks(ctx context.Context, s schema.RO, root []byte, dst map[blobcache.OID]blobcache.ActionSet) error {
 	err := sch.WalkOIDs(ctx, s, cadata.IDFromBytes(root), func(oid blobcache.OID) error {
 		dst[oid] = blobcache.Action_ALL
 		return nil

--- a/src/schema/basicns/basicns.go
+++ b/src/schema/basicns/basicns.go
@@ -34,8 +34,8 @@ var _ schema.Container = &Schema{}
 
 type Schema struct{}
 
-func (sch Schema) Validate(ctx context.Context, s cadata.Getter, _, next []byte) error {
-	_, err := sch.ListEntries(ctx, s, next)
+func (sch Schema) Validate(ctx context.Context, s schema.RO, _, next []byte) error {
+	_, err := sch.ListEntries(ctx, s.(cadata.Getter), next)
 	if err != nil {
 		return err
 	}
@@ -62,8 +62,8 @@ func (sch Schema) ListEntries(ctx context.Context, s cadata.Getter, root []byte)
 	return ents, nil
 }
 
-func (sch Schema) ReadLinks(ctx context.Context, s cadata.Getter, root []byte, dst map[blobcache.OID]blobcache.ActionSet) error {
-	ents, err := sch.ListEntries(ctx, s, root)
+func (sch Schema) ReadLinks(ctx context.Context, s schema.RO, root []byte, dst map[blobcache.OID]blobcache.ActionSet) error {
+	ents, err := sch.ListEntries(ctx, s.(cadata.Getter), root)
 	if err != nil {
 		return err
 	}

--- a/src/schema/basicns/client.go
+++ b/src/schema/basicns/client.go
@@ -11,7 +11,6 @@ import (
 type Client struct {
 	Service blobcache.Service
 	Schema  Schema
-	PeerID  *blobcache.PeerID
 }
 
 // CreateAt creates a new Volume using spec, and links it to volh.
@@ -24,7 +23,7 @@ func (c *Client) CreateAt(ctx context.Context, nsh blobcache.Handle, name string
 	if err != nil {
 		return nil, err
 	}
-	volh, err := c.Service.CreateVolume(ctx, c.PeerID, spec)
+	volh, err := c.Service.CreateVolume(ctx, nil, spec)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +126,7 @@ func (c *Client) GetEntry(ctx context.Context, volh blobcache.Handle, name strin
 
 func (c *Client) resolve(ctx context.Context, volh blobcache.Handle) (blobcache.Handle, error) {
 	if volh.Secret == ([16]byte{}) {
-		volh2, err := c.Service.OpenAs(ctx, c.PeerID, volh.OID, blobcache.Action_ALL)
+		volh2, err := c.Service.OpenAs(ctx, volh.OID, blobcache.Action_ALL)
 		if err != nil {
 			return blobcache.Handle{}, err
 		}

--- a/src/schema/glfs/glfs.go
+++ b/src/schema/glfs/glfs.go
@@ -16,13 +16,13 @@ type Schema struct {
 	Mach *glfs.Machine
 }
 
-func (sch *Schema) Validate(ctx context.Context, src cadata.Getter, prev, next []byte) error {
+func (sch *Schema) Validate(ctx context.Context, src schema.RO, prev, next []byte) error {
 	if len(prev) == 0 {
 		nextRef, err := ParseRef(next)
 		if err != nil {
 			return err
 		}
-		return sch.Mach.WalkRefs(ctx, src, *nextRef, func(ref glfs.Ref) error {
+		return sch.Mach.WalkRefs(ctx, src.(cadata.Getter), *nextRef, func(ref glfs.Ref) error {
 			return nil
 		})
 	}
@@ -34,7 +34,7 @@ func (sch *Schema) Validate(ctx context.Context, src cadata.Getter, prev, next [
 	if err != nil {
 		return err
 	}
-	return DiffRefs(ctx, src, *prevRef, *nextRef, func(left, right *glfs.Ref) error { return nil })
+	return DiffRefs(ctx, src.(cadata.Getter), *prevRef, *nextRef, func(left, right *glfs.Ref) error { return nil })
 }
 
 func ParseRef(root []byte) (*glfs.Ref, error) {

--- a/src/schema/schema.go
+++ b/src/schema/schema.go
@@ -5,14 +5,13 @@ import (
 	"context"
 
 	"blobcache.io/blobcache/src/blobcache"
-	"go.brendoncarroll.net/state/cadata"
 )
 
 // Schema is the most general Schema type.
 // All a Schema has to be able to do is validate the contents of a Volume.
 type Schema interface {
 	// Validate returns nil if the contents of the volume are valid.
-	Validate(ctx context.Context, s cadata.Getter, prev, next []byte) error
+	Validate(ctx context.Context, s RO, prev, next []byte) error
 }
 
 // Link is a reference from one volume to another.
@@ -28,12 +27,31 @@ type Container interface {
 	Schema
 
 	// ReadLinks returns a list of links for a given root.
-	ReadLinks(ctx context.Context, s cadata.Getter, root []byte, dst map[blobcache.OID]blobcache.ActionSet) error
+	ReadLinks(ctx context.Context, s RO, root []byte, dst map[blobcache.OID]blobcache.ActionSet) error
 }
 
 // None is a Schema which does not impose any constraints on the contents of a volume.
 type None struct{}
 
-func (None) Validate(ctx context.Context, s cadata.Getter, prev, next []byte) error {
+func (None) Validate(ctx context.Context, s RO, prev, next []byte) error {
 	return nil
+}
+
+// RO is read-only Store methods
+type RO interface {
+	Get(ctx context.Context, cid blobcache.CID, buf []byte) (int, error)
+	Exists(ctx context.Context, cids []blobcache.CID, dst []bool) error
+	MaxSize() int
+}
+
+// RW is Read-Write Store methods
+type RW interface {
+	RO
+	Post(ctx context.Context, data []byte) (blobcache.CID, error)
+}
+
+// RWD is Read-Write-Delete Store methods
+type RWD interface {
+	RW
+	Delete(ctx context.Context, cids []blobcache.CID) error
 }


### PR DESCRIPTION
- blobcache: Changes Service.CreateVolume to take an additional parameter `host *Endpoint` and removes the caller ID.
- bclocal: adds back the peerView type to restrict access from peers.