### PR TITLE
Adds new internal package bcp.

### DIFF
--- a/src/bcremote/bcremote.go
+++ b/src/bcremote/bcremote.go
@@ -13,6 +13,7 @@ import (
 
 	"blobcache.io/blobcache/src/blobcache"
 	"blobcache.io/blobcache/src/internal/bcnet"
+	"blobcache.io/blobcache/src/internal/bcp"
 )
 
 // Dial starts listening via UDP on any available port, then
@@ -79,23 +80,23 @@ func (s *Service) Endpoint(ctx context.Context) (blobcache.Endpoint, error) {
 }
 
 func (s *Service) Drop(ctx context.Context, h blobcache.Handle) error {
-	return bcnet.Drop(ctx, s.node, s.ep, h)
+	return bcp.Drop(ctx, s.node, s.ep, h)
 }
 
 func (s *Service) KeepAlive(ctx context.Context, hs []blobcache.Handle) error {
-	return bcnet.KeepAlive(ctx, s.node, s.ep, hs)
+	return bcp.KeepAlive(ctx, s.node, s.ep, hs)
 }
 
 func (s *Service) Share(ctx context.Context, h blobcache.Handle, to blobcache.PeerID, mask blobcache.ActionSet) (*blobcache.Handle, error) {
-	return bcnet.Share(ctx, s.node, s.ep, h, to, mask)
+	return bcp.Share(ctx, s.node, s.ep, h, to, mask)
 }
 
 func (s *Service) InspectHandle(ctx context.Context, h blobcache.Handle) (*blobcache.HandleInfo, error) {
-	return bcnet.InspectHandle(ctx, s.node, s.ep, h)
+	return bcp.InspectHandle(ctx, s.node, s.ep, h)
 }
 
 func (s *Service) OpenFiat(ctx context.Context, target blobcache.OID, mask blobcache.ActionSet) (*blobcache.Handle, error) {
-	h, _, err := bcnet.OpenFiat(ctx, s.node, s.ep, target, mask)
+	h, _, err := bcp.OpenFiat(ctx, s.node, s.ep, target, mask)
 	if err != nil {
 		return nil, err
 	}
@@ -103,16 +104,16 @@ func (s *Service) OpenFiat(ctx context.Context, target blobcache.OID, mask blobc
 }
 
 func (s *Service) OpenFrom(ctx context.Context, base blobcache.Handle, target blobcache.OID, mask blobcache.ActionSet) (*blobcache.Handle, error) {
-	h, _, err := bcnet.OpenFrom(ctx, s.node, s.ep, base, target, mask)
+	h, _, err := bcp.OpenFrom(ctx, s.node, s.ep, base, target, mask)
 	return h, err
 }
 
 func (s *Service) Await(ctx context.Context, cond blobcache.Conditions) error {
-	return bcnet.Await(ctx, s.node, s.ep, cond)
+	return bcp.Await(ctx, s.node, s.ep, cond)
 }
 
 func (s *Service) BeginTx(ctx context.Context, volh blobcache.Handle, txp blobcache.TxParams) (*blobcache.Handle, error) {
-	h, info, err := bcnet.BeginTx(ctx, s.node, s.ep, volh, txp)
+	h, info, err := bcp.BeginTx(ctx, s.node, s.ep, volh, txp)
 	if err != nil {
 		return nil, err
 	}
@@ -125,46 +126,46 @@ func (s *Service) CreateVolume(ctx context.Context, host *blobcache.Endpoint, vs
 	if host != nil && *host != s.ep {
 		return nil, fmt.Errorf("bcremote: caller cannot be different from the node ID")
 	}
-	return bcnet.CreateVolume(ctx, s.node, s.ep, vspec)
+	return bcp.CreateVolume(ctx, s.node, s.ep, vspec)
 }
 
 // InspectVolume returns info about a Volume.
 func (s *Service) InspectVolume(ctx context.Context, h blobcache.Handle) (*blobcache.VolumeInfo, error) {
-	return bcnet.InspectVolume(ctx, s.node, s.ep, h)
+	return bcp.InspectVolume(ctx, s.node, s.ep, h)
 }
 
 func (s *Service) CloneVolume(ctx context.Context, caller *blobcache.PeerID, volh blobcache.Handle) (*blobcache.Handle, error) {
-	return bcnet.CloneVolume(ctx, s.node, s.ep, caller, volh)
+	return bcp.CloneVolume(ctx, s.node, s.ep, caller, volh)
 }
 
 // InspectTx returns info about a transaction.
 func (s *Service) InspectTx(ctx context.Context, tx blobcache.Handle) (*blobcache.TxInfo, error) {
-	return bcnet.InspectTx(ctx, s.node, s.ep, tx)
+	return bcp.InspectTx(ctx, s.node, s.ep, tx)
 }
 
 // Commit commits a transaction.
 func (s *Service) Commit(ctx context.Context, tx blobcache.Handle) error {
-	return bcnet.Commit(ctx, s.node, s.ep, tx, nil)
+	return bcp.Commit(ctx, s.node, s.ep, tx, nil)
 }
 
 // Abort aborts a transaction.
 func (s *Service) Abort(ctx context.Context, tx blobcache.Handle) error {
-	return bcnet.Abort(ctx, s.node, s.ep, tx)
+	return bcp.Abort(ctx, s.node, s.ep, tx)
 }
 
 // Load loads the volume root into dst
 func (s *Service) Load(ctx context.Context, tx blobcache.Handle, dst *[]byte) error {
-	return bcnet.Load(ctx, s.node, s.ep, tx, dst)
+	return bcp.Load(ctx, s.node, s.ep, tx, dst)
 }
 
 // Save writes to the volume root.
 func (s *Service) Save(ctx context.Context, tx blobcache.Handle, src []byte) error {
-	return bcnet.Save(ctx, s.node, s.ep, tx, src)
+	return bcp.Save(ctx, s.node, s.ep, tx, src)
 }
 
 // Post posts data to the volume
 func (s *Service) Post(ctx context.Context, tx blobcache.Handle, data []byte, opts blobcache.PostOpts) (blobcache.CID, error) {
-	return bcnet.Post(ctx, s.node, s.ep, tx, opts.Salt, data)
+	return bcp.Post(ctx, s.node, s.ep, tx, opts.Salt, data)
 }
 
 // Exists checks if a CID exists in the volume
@@ -172,19 +173,19 @@ func (s *Service) Exists(ctx context.Context, tx blobcache.Handle, cids []blobca
 	if len(cids) != len(dst) {
 		return fmt.Errorf("cids and dst must have the same length")
 	}
-	return bcnet.Exists(ctx, s.node, s.ep, tx, cids, dst)
+	return bcp.Exists(ctx, s.node, s.ep, tx, cids, dst)
 }
 
 // Delete deletes a CID from the volume
 func (s *Service) Delete(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID) error {
-	return bcnet.Delete(ctx, s.node, s.ep, tx, cids)
+	return bcp.Delete(ctx, s.node, s.ep, tx, cids)
 }
 
 func (s *Service) Copy(ctx context.Context, tx blobcache.Handle, srcTxns []blobcache.Handle, cids []blobcache.CID, success []bool) error {
 	if len(cids) != len(success) {
 		return fmt.Errorf("cids and success must have the same length")
 	}
-	return bcnet.AddFrom(ctx, s.node, s.ep, tx, cids, srcTxns, success)
+	return bcp.AddFrom(ctx, s.node, s.ep, tx, cids, srcTxns, success)
 }
 
 // Get returns the data for a CID.
@@ -193,28 +194,28 @@ func (s *Service) Get(ctx context.Context, tx blobcache.Handle, cid blobcache.CI
 	if err != nil {
 		return 0, err
 	}
-	return bcnet.Get(ctx, s.node, s.ep, tx, hf, cid, opts.Salt, buf)
+	return bcp.Get(ctx, s.node, s.ep, tx, hf, cid, opts.Salt, buf)
 }
 
 func (s *Service) Visit(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID) error {
-	return bcnet.Visit(ctx, s.node, s.ep, tx, cids)
+	return bcp.Visit(ctx, s.node, s.ep, tx, cids)
 }
 
 func (s *Service) IsVisited(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID, dst []bool) error {
-	return bcnet.IsVisited(ctx, s.node, s.ep, tx, cids, dst)
+	return bcp.IsVisited(ctx, s.node, s.ep, tx, cids, dst)
 }
 
 // Link allows the Volume to reference another volume.
 func (s *Service) Link(ctx context.Context, tx blobcache.Handle, subvol blobcache.Handle, mask blobcache.ActionSet) error {
-	return bcnet.Link(ctx, s.node, s.ep, tx, subvol, mask)
+	return bcp.Link(ctx, s.node, s.ep, tx, subvol, mask)
 }
 
 func (s *Service) Unlink(ctx context.Context, tx blobcache.Handle, targets []blobcache.OID) error {
-	return bcnet.Unlink(ctx, s.node, s.ep, tx, targets)
+	return bcp.Unlink(ctx, s.node, s.ep, tx, targets)
 }
 
 func (s *Service) VisitLinks(ctx context.Context, tx blobcache.Handle, targets []blobcache.OID) error {
-	return bcnet.VisitLinks(ctx, s.node, s.ep, tx, targets)
+	return bcp.VisitLinks(ctx, s.node, s.ep, tx, targets)
 }
 
 // getHashFunc finds the hash function for a transaction.
@@ -223,7 +224,7 @@ func (s *Service) getHashFunc(ctx context.Context, txh blobcache.Handle) (blobca
 	if ok {
 		return txinfo.HashAlgo.HashFunc(), nil
 	}
-	txinfo, err := bcnet.InspectTx(ctx, s.node, s.ep, txh)
+	txinfo, err := bcp.InspectTx(ctx, s.node, s.ep, txh)
 	if err != nil {
 		return nil, err
 	}

--- a/src/internal/bcnet/bcnet.go
+++ b/src/internal/bcnet/bcnet.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	"blobcache.io/blobcache/src/blobcache"
+	"blobcache.io/blobcache/src/internal/bcp"
 	"github.com/cloudflare/circl/sign/ed25519"
 	"github.com/quic-go/quic-go"
 	"go.brendoncarroll.net/exp/singleflight"
@@ -22,6 +23,10 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
+
+type Message = bcp.Message
+
+var _ bcp.Asker = (*Node)(nil)
 
 type Node struct {
 	privateKey ed25519.PrivateKey
@@ -64,7 +69,7 @@ func (n *Node) LocalEndpoint() blobcache.Endpoint {
 }
 
 // Tell opens a uni-stream to the given peer and sends the given request.
-func (n *Node) Tell(ctx context.Context, remote blobcache.Endpoint, req *Message) error {
+func (n *Node) Tell(ctx context.Context, remote blobcache.Endpoint, req bcp.Message) error {
 	conn, err := n.getConn(ctx, remote)
 	if err != nil {
 		return err

--- a/src/internal/bcnet/server.go
+++ b/src/internal/bcnet/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"blobcache.io/blobcache/src/blobcache"
+	"blobcache.io/blobcache/src/internal/bcp"
 	"go.brendoncarroll.net/stdctx/logctx"
 	"go.uber.org/zap"
 )
@@ -16,7 +17,7 @@ type TopicMessage = blobcache.TopicMessage
 
 type Server struct {
 	Access  AccessFunc
-	Deliver func(ctx context.Context, from blobcache.Endpoint, ttm TopicTellMsg) error
+	Deliver func(ctx context.Context, from blobcache.Endpoint, ttm bcp.TopicTellMsg) error
 }
 
 func (s *Server) serve(ctx context.Context, ep blobcache.Endpoint, req *Message, resp *Message) {
@@ -27,46 +28,46 @@ func (s *Server) serve(ctx context.Context, ep blobcache.Endpoint, req *Message,
 	}
 
 	switch req.Header().Code() {
-	case MT_PING:
-		resp.SetCode(MT_OK)
+	case bcp.MT_PING:
+		resp.SetCode(bcp.MT_OK)
 		resp.SetBody(nil)
 
 	// BEGIN HANDLE
-	case MT_HANDLE_DROP:
-		handleAsk(req, resp, &DropReq{}, func(req *DropReq) (*DropResp, error) {
+	case bcp.MT_HANDLE_DROP:
+		handleAsk(req, resp, &bcp.DropReq{}, func(req *bcp.DropReq) (*bcp.DropResp, error) {
 			if err := svc.Drop(ctx, req.Handle); err != nil {
 				return nil, err
 			}
-			return &DropResp{}, nil
+			return &bcp.DropResp{}, nil
 		})
-	case MT_HANDLE_INSPECT:
-		handleAsk(req, resp, &InspectHandleReq{}, func(req *InspectHandleReq) (*InspectHandleResp, error) {
+	case bcp.MT_HANDLE_INSPECT:
+		handleAsk(req, resp, &bcp.InspectHandleReq{}, func(req *bcp.InspectHandleReq) (*bcp.InspectHandleResp, error) {
 			info, err := svc.InspectHandle(ctx, req.Handle)
 			if err != nil {
 				return nil, err
 			}
-			return &InspectHandleResp{Info: *info}, nil
+			return &bcp.InspectHandleResp{Info: *info}, nil
 		})
-	case MT_HANDLE_KEEP_ALIVE:
-		handleAsk(req, resp, &KeepAliveReq{}, func(req *KeepAliveReq) (*KeepAliveResp, error) {
+	case bcp.MT_HANDLE_KEEP_ALIVE:
+		handleAsk(req, resp, &bcp.KeepAliveReq{}, func(req *bcp.KeepAliveReq) (*bcp.KeepAliveResp, error) {
 			if err := svc.KeepAlive(ctx, req.Handles); err != nil {
 				return nil, err
 			}
-			return &KeepAliveResp{}, nil
+			return &bcp.KeepAliveResp{}, nil
 		})
-	case MT_HANDLE_SHARE:
-		handleAsk(req, resp, &ShareReq{}, func(req *ShareReq) (*ShareResp, error) {
+	case bcp.MT_HANDLE_SHARE:
+		handleAsk(req, resp, &bcp.ShareReq{}, func(req *bcp.ShareReq) (*bcp.ShareResp, error) {
 			h, err := svc.Share(ctx, req.Handle, req.Peer, req.Mask)
 			if err != nil {
 				return nil, err
 			}
-			return &ShareResp{Handle: *h}, nil
+			return &bcp.ShareResp{Handle: *h}, nil
 		})
 	// END HANDLE
 
 	// BEGIN VOLUME
-	case MT_OPEN_AS:
-		handleAsk(req, resp, &OpenFiatReq{}, func(req *OpenFiatReq) (*OpenFiatResp, error) {
+	case bcp.MT_OPEN_AS:
+		handleAsk(req, resp, &bcp.OpenFiatReq{}, func(req *bcp.OpenFiatReq) (*bcp.OpenFiatResp, error) {
 			h, err := svc.OpenFiat(ctx, req.Target, req.Mask)
 			if err != nil {
 				return nil, err
@@ -75,10 +76,10 @@ func (s *Server) serve(ctx context.Context, ep blobcache.Endpoint, req *Message,
 			if err != nil {
 				return nil, err
 			}
-			return &OpenFiatResp{Handle: *h, Info: *info}, nil
+			return &bcp.OpenFiatResp{Handle: *h, Info: *info}, nil
 		})
-	case MT_OPEN_FROM:
-		handleAsk(req, resp, &OpenFromReq{}, func(req *OpenFromReq) (*OpenFromResp, error) {
+	case bcp.MT_OPEN_FROM:
+		handleAsk(req, resp, &bcp.OpenFromReq{}, func(req *bcp.OpenFromReq) (*bcp.OpenFromResp, error) {
 			h, err := svc.OpenFrom(ctx, req.Base, req.Target, req.Mask)
 			if err != nil {
 				return nil, err
@@ -87,10 +88,10 @@ func (s *Server) serve(ctx context.Context, ep blobcache.Endpoint, req *Message,
 			if err != nil {
 				return nil, err
 			}
-			return &OpenFromResp{Handle: *h, Info: *info}, nil
+			return &bcp.OpenFromResp{Handle: *h, Info: *info}, nil
 		})
-	case MT_CREATE_VOLUME:
-		handleAsk(req, resp, &CreateVolumeReq{}, func(req *CreateVolumeReq) (*CreateVolumeResp, error) {
+	case bcp.MT_CREATE_VOLUME:
+		handleAsk(req, resp, &bcp.CreateVolumeReq{}, func(req *bcp.CreateVolumeReq) (*bcp.CreateVolumeResp, error) {
 			h, err := svc.CreateVolume(ctx, nil, req.Spec)
 			if err != nil {
 				return nil, err
@@ -99,33 +100,33 @@ func (s *Server) serve(ctx context.Context, ep blobcache.Endpoint, req *Message,
 			if err != nil {
 				return nil, err
 			}
-			return &CreateVolumeResp{Handle: *h, Info: *info}, nil
+			return &bcp.CreateVolumeResp{Handle: *h, Info: *info}, nil
 		})
-	case MT_VOLUME_CLONE:
-		handleAsk(req, resp, &CloneVolumeReq{}, func(req *CloneVolumeReq) (*CloneVolumeResp, error) {
+	case bcp.MT_VOLUME_CLONE:
+		handleAsk(req, resp, &bcp.CloneVolumeReq{}, func(req *bcp.CloneVolumeReq) (*bcp.CloneVolumeResp, error) {
 			h, err := svc.CloneVolume(ctx, &ep.Peer, req.Volume)
 			if err != nil {
 				return nil, err
 			}
-			return &CloneVolumeResp{Handle: *h}, nil
+			return &bcp.CloneVolumeResp{Handle: *h}, nil
 		})
-	case MT_VOLUME_INSPECT:
-		handleAsk(req, resp, &InspectVolumeReq{}, func(req *InspectVolumeReq) (*InspectVolumeResp, error) {
+	case bcp.MT_VOLUME_INSPECT:
+		handleAsk(req, resp, &bcp.InspectVolumeReq{}, func(req *bcp.InspectVolumeReq) (*bcp.InspectVolumeResp, error) {
 			info, err := svc.InspectVolume(ctx, req.Volume)
 			if err != nil {
 				return nil, err
 			}
-			return &InspectVolumeResp{Info: *info}, nil
+			return &bcp.InspectVolumeResp{Info: *info}, nil
 		})
-	case MT_VOLUME_AWAIT:
-		handleAsk(req, resp, &AwaitReq{}, func(req *AwaitReq) (*AwaitResp, error) {
+	case bcp.MT_VOLUME_AWAIT:
+		handleAsk(req, resp, &bcp.AwaitReq{}, func(req *bcp.AwaitReq) (*bcp.AwaitResp, error) {
 			if err := svc.Await(ctx, req.Cond); err != nil {
 				return nil, err
 			}
-			return &AwaitResp{}, nil
+			return &bcp.AwaitResp{}, nil
 		})
-	case MT_VOLUME_BEGIN_TX:
-		handleAsk(req, resp, &BeginTxReq{}, func(req *BeginTxReq) (*BeginTxResp, error) {
+	case bcp.MT_VOLUME_BEGIN_TX:
+		handleAsk(req, resp, &bcp.BeginTxReq{}, func(req *bcp.BeginTxReq) (*bcp.BeginTxResp, error) {
 			h, err := svc.BeginTx(ctx, req.Volume, req.Params)
 			if err != nil {
 				return nil, err
@@ -134,13 +135,13 @@ func (s *Server) serve(ctx context.Context, ep blobcache.Endpoint, req *Message,
 			if err != nil {
 				return nil, err
 			}
-			return &BeginTxResp{Tx: *h, Info: *info}, nil
+			return &bcp.BeginTxResp{Tx: *h, Info: *info}, nil
 		})
 	// END VOLUME
 
 	// BEGIN TX
-	case MT_TX_COMMIT:
-		handleAsk(req, resp, &CommitReq{}, func(req *CommitReq) (*CommitResp, error) {
+	case bcp.MT_TX_COMMIT:
+		handleAsk(req, resp, &bcp.CommitReq{}, func(req *bcp.CommitReq) (*bcp.CommitResp, error) {
 			if req.Root != nil {
 				if err := svc.Save(ctx, req.Tx, *req.Root); err != nil {
 					return nil, err
@@ -149,54 +150,54 @@ func (s *Server) serve(ctx context.Context, ep blobcache.Endpoint, req *Message,
 			if err := svc.Commit(ctx, req.Tx); err != nil {
 				return nil, err
 			}
-			return &CommitResp{}, nil
+			return &bcp.CommitResp{}, nil
 		})
-	case MT_TX_INSPECT:
-		handleAsk(req, resp, &InspectTxReq{}, func(req *InspectTxReq) (*InspectTxResp, error) {
+	case bcp.MT_TX_INSPECT:
+		handleAsk(req, resp, &bcp.InspectTxReq{}, func(req *bcp.InspectTxReq) (*bcp.InspectTxResp, error) {
 			info, err := svc.InspectTx(ctx, req.Tx)
 			if err != nil {
 				return nil, err
 			}
-			return &InspectTxResp{Info: *info}, nil
+			return &bcp.InspectTxResp{Info: *info}, nil
 		})
-	case MT_TX_ABORT:
-		handleAsk(req, resp, &AbortReq{}, func(req *AbortReq) (*AbortResp, error) {
+	case bcp.MT_TX_ABORT:
+		handleAsk(req, resp, &bcp.AbortReq{}, func(req *bcp.AbortReq) (*bcp.AbortResp, error) {
 			if err := svc.Abort(ctx, req.Tx); err != nil {
 				return nil, err
 			}
-			return &AbortResp{}, nil
+			return &bcp.AbortResp{}, nil
 		})
-	case MT_TX_LOAD:
-		handleAsk(req, resp, &LoadReq{}, func(req *LoadReq) (*LoadResp, error) {
+	case bcp.MT_TX_LOAD:
+		handleAsk(req, resp, &bcp.LoadReq{}, func(req *bcp.LoadReq) (*bcp.LoadResp, error) {
 			var root []byte
 			if err := svc.Load(ctx, req.Tx, &root); err != nil {
 				return nil, err
 			}
-			return &LoadResp{Root: root}, nil
+			return &bcp.LoadResp{Root: root}, nil
 		})
-	case MT_TX_SAVE:
-		handleAsk(req, resp, &SaveReq{}, func(req *SaveReq) (*SaveResp, error) {
+	case bcp.MT_TX_SAVE:
+		handleAsk(req, resp, &bcp.SaveReq{}, func(req *bcp.SaveReq) (*bcp.SaveResp, error) {
 			if err := svc.Save(ctx, req.Tx, req.Root); err != nil {
 				return nil, err
 			}
-			return &SaveResp{}, nil
+			return &bcp.SaveResp{}, nil
 		})
-	case MT_TX_EXISTS:
-		handleAsk(req, resp, &ExistsReq{}, func(req *ExistsReq) (*ExistsResp, error) {
+	case bcp.MT_TX_EXISTS:
+		handleAsk(req, resp, &bcp.ExistsReq{}, func(req *bcp.ExistsReq) (*bcp.ExistsResp, error) {
 			exists := make([]bool, len(req.CIDs))
 			if err := svc.Exists(ctx, req.Tx, req.CIDs, exists); err != nil {
 				return nil, err
 			}
-			return &ExistsResp{Exists: exists}, nil
+			return &bcp.ExistsResp{Exists: exists}, nil
 		})
-	case MT_TX_DELETE:
-		handleAsk(req, resp, &DeleteReq{}, func(req *DeleteReq) (*DeleteResp, error) {
+	case bcp.MT_TX_DELETE:
+		handleAsk(req, resp, &bcp.DeleteReq{}, func(req *bcp.DeleteReq) (*bcp.DeleteResp, error) {
 			if err := svc.Delete(ctx, req.Tx, req.CIDs); err != nil {
 				return nil, err
 			}
-			return &DeleteResp{}, nil
+			return &bcp.DeleteResp{}, nil
 		})
-	case MT_TX_POST:
+	case bcp.MT_TX_POST:
 		h, body, err := readHandle(req.Body())
 		if err != nil {
 			resp.SetError(err)
@@ -207,9 +208,9 @@ func (s *Server) serve(ctx context.Context, ep blobcache.Endpoint, req *Message,
 			resp.SetError(err)
 			return
 		}
-		resp.SetCode(MT_OK)
+		resp.SetCode(bcp.MT_OK)
 		resp.SetBody(cid[:])
-	case MT_TX_POST_SALT:
+	case bcp.MT_TX_POST_SALT:
 		h, body, err := readHandle(req.Body())
 		if err != nil {
 			resp.SetError(err)
@@ -226,17 +227,17 @@ func (s *Server) serve(ctx context.Context, ep blobcache.Endpoint, req *Message,
 			resp.SetError(err)
 			return
 		}
-		resp.SetCode(MT_OK)
+		resp.SetCode(bcp.MT_OK)
 		resp.SetBody(cid[:])
-	case MT_TX_ADD_FROM:
-		handleAsk(req, resp, &AddFromReq{}, func(req *AddFromReq) (*AddFromResp, error) {
+	case bcp.MT_TX_ADD_FROM:
+		handleAsk(req, resp, &bcp.AddFromReq{}, func(req *bcp.AddFromReq) (*bcp.AddFromResp, error) {
 			success := make([]bool, len(req.CIDs))
 			if err := svc.Copy(ctx, req.Tx, req.Srcs, req.CIDs, success); err != nil {
 				return nil, err
 			}
-			return &AddFromResp{Added: success}, nil
+			return &bcp.AddFromResp{Added: success}, nil
 		})
-	case MT_TX_GET:
+	case bcp.MT_TX_GET:
 		h, body, err := readHandle(req.Body())
 		if err != nil {
 			resp.SetError(err)
@@ -260,50 +261,50 @@ func (s *Server) serve(ctx context.Context, ep blobcache.Endpoint, req *Message,
 			resp.SetError(err)
 			return
 		}
-		resp.SetCode(MT_OK)
+		resp.SetCode(bcp.MT_OK)
 		resp.SetBody(buf[:n])
-	case MT_TX_LINK:
-		handleAsk(req, resp, &LinkReq{}, func(req *LinkReq) (*LinkResp, error) {
+	case bcp.MT_TX_LINK:
+		handleAsk(req, resp, &bcp.LinkReq{}, func(req *bcp.LinkReq) (*bcp.LinkResp, error) {
 			if err := svc.Link(ctx, req.Tx, req.Subvol, req.Mask); err != nil {
 				return nil, err
 			}
-			return &LinkResp{}, nil
+			return &bcp.LinkResp{}, nil
 		})
-	case MT_TX_UNLINK:
-		handleAsk(req, resp, &UnlinkReq{}, func(req *UnlinkReq) (*UnlinkResp, error) {
+	case bcp.MT_TX_UNLINK:
+		handleAsk(req, resp, &bcp.UnlinkReq{}, func(req *bcp.UnlinkReq) (*bcp.UnlinkResp, error) {
 			if err := svc.Unlink(ctx, req.Tx, req.Targets); err != nil {
 				return nil, err
 			}
-			return &UnlinkResp{}, nil
+			return &bcp.UnlinkResp{}, nil
 		})
-	case MT_TX_VISIT_LINKS:
-		handleAsk(req, resp, &VisitLinksReq{}, func(req *VisitLinksReq) (*VisitLinksResp, error) {
+	case bcp.MT_TX_VISIT_LINKS:
+		handleAsk(req, resp, &bcp.VisitLinksReq{}, func(req *bcp.VisitLinksReq) (*bcp.VisitLinksResp, error) {
 			if err := svc.VisitLinks(ctx, req.Tx, req.Targets); err != nil {
 				return nil, err
 			}
-			return &VisitLinksResp{}, nil
+			return &bcp.VisitLinksResp{}, nil
 		})
-	case MT_TX_VISIT:
-		handleAsk(req, resp, &VisitReq{}, func(req *VisitReq) (*VisitResp, error) {
+	case bcp.MT_TX_VISIT:
+		handleAsk(req, resp, &bcp.VisitReq{}, func(req *bcp.VisitReq) (*bcp.VisitResp, error) {
 			if err := svc.Visit(ctx, req.Tx, req.CIDs); err != nil {
 				return nil, err
 			}
-			return &VisitResp{}, nil
+			return &bcp.VisitResp{}, nil
 		})
-	case MT_TX_IS_VISITED:
-		handleAsk(req, resp, &IsVisitedReq{}, func(req *IsVisitedReq) (*IsVisitedResp, error) {
+	case bcp.MT_TX_IS_VISITED:
+		handleAsk(req, resp, &bcp.IsVisitedReq{}, func(req *bcp.IsVisitedReq) (*bcp.IsVisitedResp, error) {
 			visited := make([]bool, len(req.CIDs))
 			if err := svc.IsVisited(ctx, req.Tx, req.CIDs, visited); err != nil {
 				return nil, err
 			}
-			return &IsVisitedResp{Visited: visited}, nil
+			return &bcp.IsVisitedResp{Visited: visited}, nil
 		})
 	// END TX
 
 	// BEGIN TOPIC
-	case MT_TOPIC_TELL:
+	case bcp.MT_TOPIC_TELL:
 		if err := func() error {
-			var ttm TopicTellMsg
+			var ttm bcp.TopicTellMsg
 			if err := ttm.Unmarshal(req.Body()); err != nil {
 				return err
 			}
@@ -351,6 +352,6 @@ func handleAsk[Req Unmarshaller, Resp Marshaller](req *Message, resp *Message, z
 		return
 	}
 	data := (*respR).Marshal(nil)
-	resp.SetCode(MT_OK)
+	resp.SetCode(bcp.MT_OK)
 	resp.SetBody(data)
 }

--- a/src/internal/bcp/bcp_test.go
+++ b/src/internal/bcp/bcp_test.go
@@ -1,4 +1,4 @@
-package bcnet
+package bcp
 
 import (
 	"bytes"

--- a/src/internal/bcp/message.go
+++ b/src/internal/bcp/message.go
@@ -1,4 +1,4 @@
-package bcnet
+package bcp
 
 import (
 	"encoding/binary"
@@ -190,7 +190,7 @@ func (m *Message) SetError(err error) {
 	m.SetBody(jsonMarshal(err))
 }
 
-func ParseWireError(code MessageType, x []byte) error {
+func parseWireError(code MessageType, x []byte) error {
 	var ret error
 	switch code {
 	case MT_ERROR_INVALID_HANDLE:

--- a/src/internal/bcp/rpc_message.go
+++ b/src/internal/bcp/rpc_message.go
@@ -1,4 +1,4 @@
-package bcnet
+package bcp
 
 import (
 	"crypto/rand"

--- a/src/internal/volumes/remotevol/system.go
+++ b/src/internal/volumes/remotevol/system.go
@@ -8,6 +8,7 @@ import (
 
 	"blobcache.io/blobcache/src/blobcache"
 	"blobcache.io/blobcache/src/internal/bcnet"
+	"blobcache.io/blobcache/src/internal/bcp"
 	"blobcache.io/blobcache/src/internal/volumes"
 )
 
@@ -41,7 +42,7 @@ func (sys *System) Up(ctx context.Context, p Params) (*Volume, error) {
 		return vol, nil
 	}
 	// TODO: shouldn't use the network with the lock held.
-	volh, info, err := bcnet.OpenFiat(ctx, node, p.Endpoint, p.Volume, blobcache.Action_ALL)
+	volh, info, err := bcp.OpenFiat(ctx, node, p.Endpoint, p.Volume, blobcache.Action_ALL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Package for the Blobcache Protocol (BCP)
- It provides the BCP messages, and functions for doing rpc.
- Eventually this package could be made public, which is the reason for splitting it out.  bcnet
will probably remain internal for the foreseeable
future.