### PR TITLE
blobcache: cleanup actions

### DIFF
--- a/client/rs/src/types.rs
+++ b/client/rs/src/types.rs
@@ -359,7 +359,7 @@ pub struct Info {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Endpoint {
-    pub peer: NodeID,
+    pub node: NodeID,
     pub ip_port: String,
 }
 
@@ -382,7 +382,7 @@ impl Endpoint {
             format!("[{ip}]:{port}")
         };
         Ok(Self {
-            peer: NodeID(peer),
+            node: NodeID(peer),
             ip_port,
         })
     }

--- a/doc/9.02_Blobcache_vs_IPFS.md
+++ b/doc/9.02_Blobcache_vs_IPFS.md
@@ -1,0 +1,38 @@
+# Blobcache vs. IPFS
+
+## Volumes vs. Name + Blocks
+Blobcache Volumes are similar to an IPNS name and the set of IPFS blocks that can be transitively reached from it. A significant difference is that Blobcache Volumes expose a transaction API with serializable isolation semantics. IPFS provides distributed, available-but-inconsistent, cryptographically signed cells. IPFS chooses availability, and Blobcache chooses consistency. A Blobcache Volume corresponds to a specific entity maintained and controlled by a specific Node. An IPFS name exists as a distributed entity on the network.
+
+Most applications need some sort of consistent transactional cell (even if they don't realize it).
+In order to be useful, inconsistent-but-available cells have to be used carefully in an application-specific way.
+This required application-specific care is one reason for the lack of adoption of [CRDTs](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type).
+
+## Complicated Flexibility
+IPFS tries to be maximally flexible; every decision point in the architecture has multiple implementations.
+This contributes to significant complexity across the ecosystem.
+
+As an example, the Multihash format is pervasive in the IPFS ecosystem.
+It amounts to a tag for the algorithm used to create a hash, followed by the hash output.
+This means that every single hash in a data structure could use a different algorithm, and the algorithm is determined by the data.
+That approach accommodates unrealistic use cases at the cost of performance and implementation complexity.
+Typically, a hash-linked data structure is built using a single hash algorithm, and the chosen algorithm is part of the security assumptions.
+If the data can convince you to use a different hash algorithm, then the security is only as good as the weakest hash algorithm in the system.
+
+Blobcache allows each Volume to choose a hash algorithm, and all of the blobs within a Volume are identified using that algorithm.
+The algorithm used only needs to be stored once per Volume, and the Volume configuration carries the security assumption.
+If the user doesn't trust a particular hash function, they can create a Volume that doesn't use it.
+
+## Public vs. Private
+IPFS is a public network.
+The only option for privacy is to create a completely separate private network.
+IPFS nodes connect to other nodes owned by other people using a DHT.
+This DHT is used to track the location of blobs in a global context.
+A Node can request any blob from any other Node, and the default is for the serving Node to give out the requested blob without any kind of authorization check.
+IPFS is similar to Bittorrent in this way.
+
+A Blobcache Node only dials connections to Nodes when the user asks to connect to a remote Node.
+A Blobcache Node only accepts connections from other Nodes if it has been configured to.
+Each Volume in Blobcache requires permission to access.
+That permission can be given out to specific trusted peers by configuring the host Node's policy.
+Or it can be encapsulated in a LinkToken and stored in a Volume, which gives access to everyone who can see the containing Volume.
+A Blobcache Node can be used to store public and private data simultaneously.

--- a/src/bclocal/api_test.go
+++ b/src/bclocal/api_test.go
@@ -95,7 +95,7 @@ func (l *testPeerLocator) Add(ep blobcache.Endpoint) {
 	if l.peers == nil {
 		l.peers = make(map[blobcache.NodeID]netip.AddrPort)
 	}
-	l.peers[ep.Peer] = ep.IPPort
+	l.peers[ep.Node] = ep.IPPort
 }
 
 func (l *testPeerLocator) WhereIs(_ context.Context, peer blobcache.NodeID) iter.Seq[netip.AddrPort] {

--- a/src/bcsdk/bcsdk.go
+++ b/src/bcsdk/bcsdk.go
@@ -43,7 +43,7 @@ func CreateOnSameHost(ctx context.Context, s blobcache.Service, base blobcache.H
 			return nil, nil, err
 		}
 		return svolh, &blobcache.FQOID{
-			Node: ep.Peer,
+			Node: ep.Node,
 			OID:  svolh.OID,
 		}, nil
 	}
@@ -54,7 +54,7 @@ func OpenURL(ctx context.Context, bc blobcache.Service, u blobcache.URL) (*blobc
 	if err != nil {
 		return nil, err
 	}
-	if localEP.Peer == u.Node {
+	if localEP.Node == u.Node {
 		volh, err := bc.OpenFiat(ctx, u.Base, blobcache.Action_ALL)
 		if err != nil {
 			return nil, err
@@ -103,7 +103,7 @@ func URLFor(ctx context.Context, bc blobcache.Service, volh blobcache.Handle) (*
 		voloid = vinfo.Backend.Remote.Volume
 	}
 	return &blobcache.URL{
-		Node: host.Peer,
+		Node: host.Node,
 		Base: voloid,
 	}, nil
 }

--- a/src/blobcache/blobcachetests/multinode.go
+++ b/src/blobcache/blobcachetests/multinode.go
@@ -93,8 +93,8 @@ func TestMultiNode(t *testing.T, mk func(t testing.TB, n int) []blobcache.Servic
 			vol1 := CreateVolume(t, s1, nil, defaultLocalSpec())
 			ep, err := s1.Endpoint(ctx)
 			require.NoError(t, err)
-			t.Log("creating peer volume", ep.Peer, vol1.OID)
-			vol2 := CreateVolume(t, s2, nil, peerVolumeSpec(ep.Peer, vol1.OID))
+			t.Log("creating peer volume", ep.Node, vol1.OID)
+			vol2 := CreateVolume(t, s2, nil, peerVolumeSpec(ep.Node, vol1.OID))
 			t.Log("setup peer volume, handing over to TxAPI test")
 			return s2, vol2
 		})

--- a/src/blobcache/blobcachetests/util.go
+++ b/src/blobcache/blobcachetests/util.go
@@ -40,7 +40,7 @@ func CreateOnSameHost(t testing.TB, s blobcache.Service, base blobcache.Handle, 
 		ep, err := s.Endpoint(ctx)
 		require.NoError(t, err)
 		return *svolh, blobcache.FQOID{
-			Node: ep.Peer,
+			Node: ep.Node,
 			OID:  svolh.OID,
 		}
 	}

--- a/src/blobcache/fq.go
+++ b/src/blobcache/fq.go
@@ -119,7 +119,7 @@ func (u *URL) Endpoint() *Endpoint {
 		return nil
 	}
 	return &Endpoint{
-		Peer:   u.Node,
+		Node:   u.Node,
 		IPPort: *u.IPPort,
 	}
 }

--- a/src/blobcache/handle.go
+++ b/src/blobcache/handle.go
@@ -163,116 +163,21 @@ func (a ActionSet) Share() ActionSet {
 const (
 	// Action_ACK is set on any valid handle.
 	// Valid handles can always be inspected, dropped, and kept alive.
-	Action_ACK = (1 << iota)
-
-	// Action_TX_INSPECT allows the transaction to be inspected.
-	// On a Transaction handle it gates the InspectTx operation.
-	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
-	Action_TX_INSPECT
-	// Action_TX_LOAD allows Load operations in the transaction.
-	// On a Transaction handle it gates the Load operation.
-	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
-	Action_TX_LOAD
-	// Action_TX_SAVE allows Save operations in the transaction.
-	// On a Transaction handle it gates the Save operation.
-	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
-	Action_TX_SAVE
-	// Action_TX_POST allows Post operations in the transaction.
-	// On a Transaction handle it gates the Post operation.
-	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
-	Action_TX_POST
-	// Action_TX_GET allows Get operations in the transaction.
-	// On a Transaction handle it gates the Get operation.
-	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
-	Action_TX_GET
-	// Action_TX_EXISTS allows Exists operations in the transaction.
-	// On a Transaction handle it gates the Exists operation.
-	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
-	Action_TX_EXISTS
-	// Action_TX_DELETE allows Delete operations in the transaction.
-	// On a Transaction handle it gates the Delete operation.
-	// On a Volume handle:
-	// - constrains the operations that can be performed in transactions created with that handle.
-	// - gates opening GC transactions on the volume.
-	Action_TX_DELETE
-	// Action_TX_COPY_FROM allows Copy operations to pull from this transaction.
-	// On a Transaction handle is gates using the handle as a source in a Copy operation.
-	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
-	Action_TX_COPY_FROM
-	// Action_TX_COPY_TO allows a Transaction to be written to in an Copy operation.
-	// On a Transaction handle it gates the Copy operation.
-	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
-	Action_TX_COPY_TO
-	// Action_TX_LINK_FROM allows a transaction to add a link to another Volume.
-	// It gates the AllowLink operation.
-	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
-	Action_TX_LINK_FROM
-	// Action_TX_UNLINK_FROM allows a transaction to remove a link from another Volume.
-	// It gates the Unlink operation.
-	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
-	Action_TX_UNLINK_FROM
-)
-
-const (
-	// Action_VOLUME_INSPECT allows the inspection of volumes.
-	// It has no effect on a Transaction handle.
-	Action_VOLUME_INSPECT = 1 << 24
-	// Action_VOLUME_BEGIN_TX allows the beginning of transactions on a volume
-	// It has no effect on a Transaction handle.
-	Action_VOLUME_BEGIN_TX = 1 << 25
-	// Action_VOLUME_LINK_TO allows a volume to be linked to in an AllowLink operation.
-	// If this is not set, then there is no way for the volume to be persisted.
-	// It has no effect on a Transaction handle.
-	Action_VOLUME_LINK_TO = 1 << 26
-	// Action_VOLUME_SUB_TO allows a Queue to be subscribed
-	// to a Volume's changes.
-	Action_VOLUME_SUB_TO = 1 << 27
-
-	// Action_VOLUME_CLONE allows the Volume to be cloned.
-	// It has no effect on a Transaction handle.
-	Action_VOLUME_CLONE = 1 << 30
-	// Action_VOLUME_CREATE allows the creation of volumes.
-	// This is never used on a Volume or Transaction handle.
-	// But it is useful to be able to refer to it with the other actions using the ActionSet type.
-	Action_VOLUME_CREATE = 1 << 31
-)
-
-const (
-	//Action_QUEUE_INSPECT allows the queue to be inspected
-	Action_QUEUE_INSPECT = 1 << (iota + 1)
-	// Action_QUEUE_NEXT allows items to be read form the Queue
-	Action_QUEUE_NEXT
-	// Action_QUEUE_INSERT allows items to be inserted into the Queue
-	Action_QUEUE_INSERT
-	// Action_QUEUE_SUB_VOLUME allows the Queue to be subscribe to volumes
-	Action_QUEUE_SUB_VOLUME
-
-	// Action_QUEUE_CREATE allows creation of queues.
-	// This is never used on a handle
-	// But it is useful to be able to refer to it with the other actions using the ActionSet type.
-	Action_QUEUE_CREATE = 1 << 31
+	Action_ACK = ActionSet(1 << iota)
+	// Action_INSPECT allows the object to be inspected.
+	// This is universal across all object types
+	Action_INSPECT
 )
 
 const (
 	// Action_SHARE_ACK is set if the handle is allowed to be shared.
 	Action_SHARE_ACK = Action_ACK << 32
-	// Action_SHARE_TX_INSPECT masks TX_INSPECT if the handle is shared.
-	Action_SHARE_TX_INSPECT = Action_TX_INSPECT << 32
-	// Action_SHARE_TX_LOAD masks TX_LOAD if the handle is shared.
-	Action_SHARE_TX_LOAD = Action_TX_LOAD << 32
-	// Action_SHARE_TX_POST masks TX_POST if the handle is shared.
-	Action_SHARE_TX_POST = Action_TX_POST << 32
-	// Action_SHARE_TX_GET masks TX_GET if the handle is shared.
-	Action_SHARE_TX_GET = Action_TX_GET << 32
-	// Action_SHARE_TX_EXISTS masks TX_EXISTS if the handle is shared.
-	Action_SHARE_TX_EXISTS = Action_TX_EXISTS << 32
-	// Action_SHARE_TX_DELETE masks TX_DELETE if the handle is shared.
-	Action_SHARE_TX_DELETE = Action_TX_DELETE << 32
-	// Action_SHARE_TX_ADD_FROM masks TX_ADD_FROM if the handle is shared.
-	Action_SHARE_TX_ADD_FROM = Action_TX_COPY_FROM << 32
-	// Action_SHARE_TX_LINK_FROM masks TX_LINK_FROM if the handle is shared.
-	Action_SHARE_TX_LINK_FROM = Action_TX_LINK_FROM << 32
 )
+
+// SharedAction returns the shared ActionSet for an ActionSet.
+func SharedAction(x ActionSet) ActionSet {
+	return x << 32
+}
 
 const Action_ALL = ^ActionSet(0)
 
@@ -298,31 +203,9 @@ func (r ActionSet) String() string {
 	case 0:
 		return "NONE"
 	}
-	parts := []string{}
-	rs := map[ActionSet]string{
-		Action_ACK: "ACK",
+	return fmt.Sprintf("%064b", r)
+}
 
-		Action_TX_INSPECT:   "TX_INSPECT",
-		Action_TX_LOAD:      "TX_LOAD",
-		Action_TX_POST:      "TX_POST",
-		Action_TX_GET:       "TX_GET",
-		Action_TX_EXISTS:    "TX_EXISTS",
-		Action_TX_DELETE:    "TX_DELETE",
-		Action_TX_COPY_FROM: "TX_COPY_FROM",
-		Action_TX_COPY_TO:   "TX_COPY_TO",
-		Action_TX_LINK_FROM: "TX_LINK_FROM",
-
-		Action_VOLUME_INSPECT:  "VOLUME_INSPECT",
-		Action_VOLUME_BEGIN_TX: "VOLUME_BEGIN_TX",
-		Action_VOLUME_SUB_TO:   "VOLUME_SUB_TO",
-		Action_VOLUME_LINK_TO:  "VOLUME_LINK_TO",
-		Action_VOLUME_CLONE:    "VOLUME_CLONE",
-		Action_VOLUME_CREATE:   "VOLUME_CREATE",
-	}
-	for r2, str := range rs {
-		if r&r2 != 0 {
-			parts = append(parts, str)
-		}
-	}
-	return strings.Join(parts, "|")
+func (a ActionSet) Has(b ActionSet) bool {
+	return a&b == b
 }

--- a/src/blobcache/queues.go
+++ b/src/blobcache/queues.go
@@ -77,6 +77,17 @@ func (vs *VolSubSpec) Unmarshal(data []byte) error {
 	return json.Unmarshal(data, vs)
 }
 
+const (
+	//Action_QUEUE_INSPECT allows the queue to be inspected
+	Action_QUEUE_INSPECT = ActionSet(1 << (iota + 1))
+	// Action_QUEUE_NEXT allows items to be read form the Queue
+	Action_QUEUE_ENQUEUE
+	// Action_QUEUE_INSERT allows items to be inserted into the Queue
+	Action_QUEUE_DEQUEUE
+	// Action_QUEUE_SUB_VOLUME allows the Queue to be subscribed to volumes
+	Action_QUEUE_SUB_VOLUME
+)
+
 type QueueAPI interface {
 	// CreateQueue creates a new queue and returns a handle to it.
 	CreateQueue(ctx context.Context, host *Endpoint, qspec QueueSpec) (*Handle, error)

--- a/src/blobcache/volume.go
+++ b/src/blobcache/volume.go
@@ -14,6 +14,45 @@ import (
 	"go.inet256.org/inet256/src/inet256"
 )
 
+const (
+	// Action_VOLUME_INSPECT allows the inspection of volumes.
+	// It has no effect on a Transaction handle.
+	Action_VOLUME_INSPECT = Action_INSPECT
+	// Action_VOLUME_BEGIN_TX allows the beginning of transactions on a volume
+	// It has no effect on a Transaction handle.
+	Action_VOLUME_BEGIN_TX = ActionSet(1 << (iota + 1))
+	// Action_VOLUME_LINK_TO allows a volume to be linked to in an AllowLink operation.
+	// If this is not set, then there is no way for the volume to be persisted.
+	// It has no effect on a Transaction handle.
+	Action_VOLUME_LINK_TO
+	// Action_VOLUME_SUBCRIBE allows a Queue to be subscribed
+	// to a Volume's changes.
+	Action_VOLUME_SUBSCRIBE
+
+	action_VOLUME_MAX = 1 << 8
+)
+
+const (
+	// Action_VOLUME_TX_INSPECT controls whether Action_TX_INSPECT is set
+	// on transactions created using this handle.
+	Action_VOLUME_TX_INSPECT = Action_TX_INSPECT << 8
+	// Action_VOLUME_TX_LOAD controls whether Action_TX_LOAD is set
+	// on transactions created using this handle.
+	Action_VOLUME_TX_LOAD        = Action_TX_LOAD << 8
+	Action_VOLUME_TX_SAVE        = Action_TX_SAVE << 8
+	Action_VOLUME_TX_POST        = Action_TX_POST << 8
+	Action_VOLUME_TX_GET         = Action_TX_GET << 8
+	Action_VOLUME_TX_EXISTS      = Action_TX_EXISTS << 8
+	Action_VOLUME_TX_DELETE      = Action_TX_DELETE << 8
+	Action_VOLUME_TX_COPY_FROM   = Action_TX_COPY_FROM << 8
+	Action_VOLUME_TX_COPY_TO     = Action_TX_COPY_TO << 8
+	Action_VOLUME_TX_LINK_FROM   = Action_TX_LINK_FROM << 8
+	Action_VOLUME_TX_UNLINK_FROM = Action_TX_UNLINK_FROM << 8
+	Action_VOLUME_TX_VISIT       = Action_TX_VISIT << 8
+	Action_VOLUME_TX_IS_VISITED  = Action_TX_IS_VISITED << 8
+	Action_VOLUME_TX_VISIT_LINKS = Action_TX_VISIT_LINKS << 8
+)
+
 type VolumeAPI interface {
 	// CreateVolume creates a new volume.
 	// CreateVolume always creates a Volume on the local Node.
@@ -38,9 +77,62 @@ type VolumeAPI interface {
 
 	// BeginTx begins a new transaction, on a Volume.
 	BeginTx(ctx context.Context, volh Handle, txp TxParams) (*Handle, error)
-	// CloneVolume clones a Volume, copying it's configuration, blobs, and cell data.
-	CloneVolume(ctx context.Context, caller *NodeID, volh Handle) (*Handle, error)
 }
+
+const (
+	// Action_TX_INSPECT allows the transaction to be inspected.
+	// On a Transaction handle it gates the InspectTx operation.
+	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
+	Action_TX_INSPECT = Action_INSPECT
+	// Action_TX_LOAD allows Load operations in the transaction.
+	// On a Transaction handle it gates the Load operation.
+	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
+	Action_TX_LOAD = (1 << (iota + 1))
+	// Action_TX_SAVE allows Save operations in the transaction.
+	// On a Transaction handle it gates the Save operation.
+	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
+	Action_TX_SAVE
+	// Action_TX_POST allows Post operations in the transaction.
+	// On a Transaction handle it gates the Post operation.
+	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
+	Action_TX_POST
+	// Action_TX_GET allows Get operations in the transaction.
+	// On a Transaction handle it gates the Get operation.
+	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
+	Action_TX_GET
+	// Action_TX_EXISTS allows Exists operations in the transaction.
+	// On a Transaction handle it gates the Exists operation.
+	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
+	Action_TX_EXISTS
+	// Action_TX_DELETE allows Delete operations in the transaction.
+	// On a Transaction handle it gates the Delete operation.
+	// On a Volume handle:
+	// - constrains the operations that can be performed in transactions created with that handle.
+	// - gates opening GC transactions on the volume.
+	Action_TX_DELETE
+	// Action_TX_COPY_FROM allows Copy operations to pull from this transaction.
+	// On a Transaction handle is gates using the handle as a source in a Copy operation.
+	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
+	Action_TX_COPY_FROM
+	// Action_TX_COPY_TO allows a Transaction to be written to in an Copy operation.
+	// On a Transaction handle it gates the Copy operation.
+	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
+	Action_TX_COPY_TO
+	// Action_TX_LINK_FROM allows a transaction to add a link to another Volume.
+	// It gates the AllowLink operation.
+	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
+	Action_TX_LINK_FROM
+	// Action_TX_UNLINK_FROM allows a transaction to remove a link to another Volume.
+	// It gates the Unlink operation.
+	// On a Volume handle it constrains the operations that can be performed in transactions created with that handle.
+	Action_TX_UNLINK_FROM
+	// Action_TX_VISIT marks a blob as visited in a GC transaction.
+	Action_TX_VISIT
+	// Action_TX_IS_VISITED checks if a blob has been visited in a GC transaction.
+	Action_TX_IS_VISITED
+	// Action_TX_VISIT_LINKS allows a GC transaction to visit links.
+	Action_TX_VISIT_LINKS
+)
 
 type TxAPI interface {
 	// InspectTx returns info about a transaction.
@@ -92,14 +184,14 @@ type TxAPI interface {
 // Endpoint is somewhere that a blobcache node can be found.
 // The Zero endpoint means the node is not available on the network.
 type Endpoint struct {
-	Peer   NodeID         `json:"peer"`
+	Node   NodeID         `json:"node"`
 	IPPort netip.AddrPort `json:"ip_port"`
 }
 
 const EndpointSize = PeerIDSize + 16 + 2
 
 func (e Endpoint) Marshal(out []byte) []byte {
-	out = append(out, e.Peer[:]...)
+	out = append(out, e.Node[:]...)
 
 	ipaddrData, err := e.IPPort.AppendBinary(nil)
 	if err != nil {
@@ -116,7 +208,7 @@ func (e *Endpoint) Unmarshal(data []byte) error {
 	if len(data) < PeerIDSize+16+2 {
 		return fmt.Errorf("too small to be endpoint")
 	}
-	e.Peer, data = NodeID(data[:PeerIDSize]), data[PeerIDSize:]
+	e.Node, data = NodeID(data[:PeerIDSize]), data[PeerIDSize:]
 	var ipaddr netip.AddrPort
 	if err := ipaddr.UnmarshalBinary(data[:16+2]); err != nil {
 		return err
@@ -126,7 +218,7 @@ func (e *Endpoint) Unmarshal(data []byte) error {
 }
 
 func (e Endpoint) String() string {
-	return fmt.Sprintf("%s:%s", e.Peer.String(), e.IPPort.String())
+	return fmt.Sprintf("%s:%s", e.Node.String(), e.IPPort.String())
 }
 
 func ParseEndpoint(s string) (Endpoint, error) {
@@ -143,7 +235,7 @@ func ParseEndpoint(s string) (Endpoint, error) {
 		return Endpoint{}, err
 	}
 	return Endpoint{
-		Peer:   peer,
+		Node:   peer,
 		IPPort: ap,
 	}, nil
 }
@@ -176,7 +268,7 @@ func (vi *VolumeInfo) GetRemoteFQOID() FQOID {
 		return FQOID{}
 	}
 	return FQOID{
-		Node: vi.Backend.Remote.Endpoint.Peer,
+		Node: vi.Backend.Remote.Endpoint.Node,
 		OID:  vi.Backend.Remote.Volume,
 	}
 }
@@ -240,7 +332,7 @@ func (v VolumeBackend[T]) String() string {
 	}
 	if v.Remote != nil {
 		sb.WriteString("remote:")
-		sb.WriteString(v.Remote.Endpoint.Peer.String())
+		sb.WriteString(v.Remote.Endpoint.Node.String())
 		sb.WriteString(" ")
 		sb.WriteString(v.Remote.Volume.String())
 	}

--- a/src/blobcachecmd/bctui/bctui.go
+++ b/src/blobcachecmd/bctui/bctui.go
@@ -776,10 +776,10 @@ func ensureHandle(ctx context.Context, svc blobcache.Service, h blobcache.Handle
 func resolveFQOID(ctx context.Context, svc blobcache.Service, h blobcache.Handle) (blobcache.FQOID, error) {
 	ep, err := svc.Endpoint(ctx)
 	if err == nil {
-		if ep.Peer == (blobcache.NodeID{}) {
+		if ep.Node == (blobcache.NodeID{}) {
 			return blobcache.FQOID{}, fmt.Errorf("endpoint returned zero peer id")
 		}
-		return blobcache.FQOID{Node: ep.Peer, OID: h.OID}, nil
+		return blobcache.FQOID{Node: ep.Node, OID: h.OID}, nil
 	}
 
 	vinfo, err := svc.InspectVolume(ctx, h)
@@ -787,11 +787,11 @@ func resolveFQOID(ctx context.Context, svc blobcache.Service, h blobcache.Handle
 		return blobcache.FQOID{}, err
 	}
 	if vinfo.Backend.Remote != nil {
-		if vinfo.Backend.Remote.Endpoint.Peer == (blobcache.NodeID{}) {
+		if vinfo.Backend.Remote.Endpoint.Node == (blobcache.NodeID{}) {
 			return blobcache.FQOID{}, fmt.Errorf("remote backend returned zero peer id")
 		}
 		return blobcache.FQOID{
-			Node: vinfo.Backend.Remote.Endpoint.Peer,
+			Node: vinfo.Backend.Remote.Endpoint.Node,
 			OID:  vinfo.Backend.Remote.Volume,
 		}, nil
 	}

--- a/src/blobcachecmd/own.go
+++ b/src/blobcachecmd/own.go
@@ -55,7 +55,7 @@ var ownCmd = star.Command{
 		spec := blobcache.VolumeSpec{
 			Remote: &blobcache.VolumeBackend_Remote{
 				Endpoint: blobcache.Endpoint{
-					Peer:   nodePeerID,
+					Node:   nodePeerID,
 					IPPort: ipPort,
 				},
 				Volume: rootOID,

--- a/src/blobcachecmd/root.go
+++ b/src/blobcachecmd/root.go
@@ -50,7 +50,6 @@ var rootCmd = star.NewDir(
 		"mkvol.vault":  mkVolVaultCmd,
 		"mkvol.git":    mkVolGitCmd,
 		"ivol":         ivolCmd,
-		"clone":        cloneVolCmd,
 		"open-fiat":    openFiatCmd,
 		"open-from":    openFromCmd,
 

--- a/src/blobcachecmd/volume.go
+++ b/src/blobcachecmd/volume.go
@@ -185,23 +185,6 @@ var ivolCmd = star.Command{
 	},
 }
 
-var cloneVolCmd = star.Command{
-	Metadata: star.Metadata{Short: "clone a volume and print handle"},
-	Pos:      []star.Positional{volHParam},
-	F: func(c star.Context) error {
-		svc, err := openService(c)
-		if err != nil {
-			return err
-		}
-		h, err := svc.CloneVolume(c.Context, nil, volHParam.Load(c))
-		if err != nil {
-			return err
-		}
-		c.Printf("%s\n", h.String())
-		return nil
-	},
-}
-
 var openFiatCmd = star.Command{
 	Metadata: star.Metadata{
 		Short: "opens a handle to an object by OID",

--- a/src/e2etest/e2e_test.go
+++ b/src/e2etest/e2e_test.go
@@ -58,7 +58,7 @@ func TestDaemonAuth(t *testing.T) {
 	peer, err := d.GetPeerID()
 	require.NoError(t, err)
 	ep := blobcache.Endpoint{
-		Peer:   peer,
+		Node:   peer,
 		IPPort: pc.LocalAddr().(*net.UDPAddr).AddrPort(),
 	}
 

--- a/src/internal/backend/remotebe/peer.go
+++ b/src/internal/backend/remotebe/peer.go
@@ -42,7 +42,7 @@ func (ps *PeerSystem) VolumeUp(ctx context.Context, p PeerParams) (*Volume, erro
 	var lastErr error
 	for addr := range ps.locator.WhereIs(ctx, p.Peer) {
 		ep := blobcache.Endpoint{
-			Peer:   p.Peer,
+			Node:   p.Peer,
 			IPPort: addr,
 		}
 		dialCtx, cf := context.WithTimeout(ctx, dialTimeout)

--- a/src/internal/backend/remotebe/system.go
+++ b/src/internal/backend/remotebe/system.go
@@ -119,7 +119,7 @@ func (sys *System) SubToVol(ctx context.Context, vol *Volume, q backend.Queue, s
 	if !ok {
 		return fmt.Errorf("bcremote: SubToVol requires a remote queue, got %T", q)
 	}
-	if rq.ep.Peer != vol.ep.Peer {
+	if rq.ep.Node != vol.ep.Node {
 		return fmt.Errorf("bcremote: SubToVol requires the queue and volume to be on the same peer")
 	}
 	return bcp.SubToVolume(ctx, vol.n, vol.ep, rq.h, vol.h, spec)

--- a/src/internal/backend/remotebe/volume.go
+++ b/src/internal/backend/remotebe/volume.go
@@ -181,7 +181,7 @@ func (tx *Tx) Link(ctx context.Context, svoid blobcache.OID, rights blobcache.Ac
 	if !ok {
 		return nil, fmt.Errorf("remotebe: can only link to remote volumes")
 	}
-	if rvol.ep.Peer != tx.vol.ep.Peer {
+	if rvol.ep.Node != tx.vol.ep.Node {
 		return nil, fmt.Errorf("remotebe: can only link to volumes on the same peer")
 	}
 	return bcp.Link(ctx, tx.vol.n, tx.vol.ep, tx.h, rvol.h, rights)

--- a/src/internal/bcnet/bcnet.go
+++ b/src/internal/bcnet/bcnet.go
@@ -64,7 +64,7 @@ func (n *Node) LocalAddr() netip.AddrPort {
 
 func (n *Node) LocalEndpoint() blobcache.Endpoint {
 	return blobcache.Endpoint{
-		Peer:   n.LocalID(),
+		Node:   n.LocalID(),
 		IPPort: n.LocalAddr(),
 	}
 }
@@ -129,7 +129,7 @@ func (n *Node) Serve(ctx context.Context, srv bcp.Handler) error {
 			continue
 		}
 		ep := blobcache.Endpoint{
-			Peer:   *peerID,
+			Node:   *peerID,
 			IPPort: ipPortFromConn(conn),
 		}
 		n.addConn(ctx, ep, conn, srv)
@@ -206,7 +206,7 @@ func (qt *Node) dialConn(ctx context.Context, ep blobcache.Endpoint) (*quic.Conn
 	raddr := net.UDPAddrFromAddrPort(ep.IPPort)
 	laddr := qt.tp.Conn.LocalAddr()
 	logctx.Info(ctx, "dialing", zap.Stringer("laddr", laddr), zap.Stringer("raddr", raddr))
-	conn, err := qt.tp.Dial(ctx, raddr, qt.makeDialTlsConfig(ep.Peer), qt.makeQuicConfig())
+	conn, err := qt.tp.Dial(ctx, raddr, qt.makeDialTlsConfig(ep.Node), qt.makeQuicConfig())
 	if err != nil {
 		logctx.Error(ctx, "dial failed", zap.Error(err), zap.Stringer("raddr", raddr))
 		return nil, err

--- a/src/internal/bcp/server.go
+++ b/src/internal/bcp/server.go
@@ -24,7 +24,7 @@ type Server struct {
 }
 
 func (s *Server) ServeBCP(ctx context.Context, ep blobcache.Endpoint, req Message, resp *Message) bool {
-	svc := s.Access(ep.Peer)
+	svc := s.Access(ep.Node)
 	if svc == nil {
 		return false
 	}
@@ -127,14 +127,6 @@ func (s *Server) ServeBCP(ctx context.Context, ep blobcache.Endpoint, req Messag
 				return nil, err
 			}
 			return &CreateVolumeResp{Handle: *h, Info: *info}, nil
-		})
-	case MT_VOLUME_CLONE:
-		handleAsk(req, resp, &CloneVolumeReq{}, func(req *CloneVolumeReq) (*CloneVolumeResp, error) {
-			h, err := svc.CloneVolume(ctx, &ep.Peer, req.Volume)
-			if err != nil {
-				return nil, err
-			}
-			return &CloneVolumeResp{Handle: *h}, nil
 		})
 	case MT_VOLUME_INSPECT:
 		handleAsk(req, resp, &InspectVolumeReq{}, func(req *InspectVolumeReq) (*InspectVolumeResp, error) {

--- a/src/internal/bcsys/bcsys.go
+++ b/src/internal/bcsys/bcsys.go
@@ -2,6 +2,7 @@ package bcsys
 
 import (
 	"context"
+	"crypto/aes"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -473,7 +474,35 @@ func (s *Service[LK, LV, LQ]) KeepAlive(ctx context.Context, hs []blobcache.Hand
 func (s *Service[LK, LV, LQ]) ShareOut(ctx context.Context, h blobcache.Handle, to blobcache.NodeID, mask blobcache.ActionSet) (*blobcache.Handle, error) {
 	logctx.Debug(ctx, "begin", zap.String("method", "Share"), zap.Stringer("oid", h.OID))
 	defer logctx.Debug(ctx, "done", zap.String("method", "Share"), zap.Stringer("oid", h.OID))
-	return nil, fmt.Errorf("Share not implemented")
+	oid, originalRights := s.handles.Resolve(h)
+	if originalRights == 0 {
+		return nil, blobcache.ErrInvalidHandle{Handle: h}
+	}
+	rights := originalRights.Share() & mask
+	if rights == 0 {
+		return nil, blobcache.ErrPermission{
+			Handle:   h,
+			Rights:   originalRights,
+			Requires: blobcache.Action_SHARE_ACK,
+		}
+	}
+	now := time.Now()
+	expiresAt := now.Add(DefaultVolumeTTL)
+	s.mu.RLock()
+	if _, exists := s.txns[oid]; exists {
+		expiresAt = now.Add(DefaultTxTTL)
+	} else if _, exists := s.queues[oid]; exists {
+		expiresAt = now.Add(DefaultQueueTTL)
+	}
+	s.mu.RUnlock()
+	out := s.handles.Create(oid, rights, now, expiresAt)
+	key := derivePeerSecret(s.tmpSecret, to)
+	ciph, err := aes.NewCipher(key[:])
+	if err != nil {
+		panic(err)
+	}
+	ciph.Encrypt(out.Secret[:], out.Secret[:])
+	return &out, nil
 }
 
 func (s *Service[LK, LV, LQ]) InspectHandle(ctx context.Context, h blobcache.Handle) (*blobcache.HandleInfo, error) {
@@ -1207,7 +1236,8 @@ func (s *Service[LK, LV, LQ]) Link(ctx context.Context, txh blobcache.Handle, ta
 	if err != nil {
 		return nil, err
 	}
-	ltok, err := txn.backend.Link(ctx, volTo.info.ID, rights&mask, volTo.backend)
+	linkRights := rights.Share() & mask
+	ltok, err := txn.backend.Link(ctx, volTo.info.ID, linkRights, volTo.backend)
 	if err != nil {
 		return nil, setErrTxOID(err, txh.OID)
 	}

--- a/src/internal/bcsys/bcsys.go
+++ b/src/internal/bcsys/bcsys.go
@@ -587,7 +587,7 @@ func (s *Service[LK, LV, LQ]) inspectRemoteForShareIn(ctx context.Context, host 
 	}
 	var lastErr error
 	for addr := range s.env.PeerLocator.WhereIs(ctx, host) {
-		ep := blobcache.Endpoint{Peer: host, IPPort: addr}
+		ep := blobcache.Endpoint{Node: host, IPPort: addr}
 		askCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 		info, err := bcp.Inspect(askCtx, node, ep, h)
 		cancel()
@@ -701,7 +701,7 @@ func (s *Service[LK, LV, LQ]) CreateVolume(ctx context.Context, host *blobcache.
 		return nil, err
 	}
 
-	if host != nil && host.Peer != s.LocalID() {
+	if host != nil && host.Node != s.LocalID() {
 		return s.createRemoteVolume(ctx, *host, vspec)
 	}
 
@@ -1183,7 +1183,7 @@ func (s *Service[LK, LV, LQ]) VisitLinks(ctx context.Context, txh blobcache.Hand
 func (s *Service[LK, LV, LQ]) CreateQueue(ctx context.Context, host *blobcache.Endpoint, qspec blobcache.QueueSpec) (*blobcache.Handle, error) {
 	logctx.Info(ctx, "begin", zap.String("method", "CreateQueue"))
 	defer logctx.Info(ctx, "done", zap.String("method", "CreateQueue"))
-	if host != nil && host.Peer != s.LocalID() {
+	if host != nil && host.Node != s.LocalID() {
 		return s.createRemoteQueue(ctx, *host, qspec)
 	}
 	if err := qspec.Validate(); err != nil {
@@ -1265,7 +1265,7 @@ func (s *Service[LK, LV, LQ]) Dequeue(ctx context.Context, qh blobcache.Handle, 
 	if len(buf) == 0 {
 		return 0, fmt.Errorf("dequeue buffer must be non-empty")
 	}
-	q, err := s.resolveQueue(ctx, qh, blobcache.Action_QUEUE_NEXT)
+	q, err := s.resolveQueue(ctx, qh, blobcache.Action_QUEUE_DEQUEUE)
 	if err != nil {
 		return 0, err
 	}
@@ -1275,7 +1275,7 @@ func (s *Service[LK, LV, LQ]) Dequeue(ctx context.Context, qh blobcache.Handle, 
 func (s *Service[LK, LV, LQ]) Enqueue(ctx context.Context, qh blobcache.Handle, msgs []blobcache.Message) (*blobcache.InsertResp, error) {
 	logctx.Debug(ctx, "begin", zap.String("method", "Enqueue"), zap.Stringer("oid", qh.OID))
 	defer logctx.Debug(ctx, "done", zap.String("method", "Enqueue"), zap.Stringer("oid", qh.OID))
-	q, err := s.resolveQueue(ctx, qh, blobcache.Action_QUEUE_INSERT)
+	q, err := s.resolveQueue(ctx, qh, blobcache.Action_QUEUE_ENQUEUE)
 	if err != nil {
 		return nil, err
 	}
@@ -1307,11 +1307,11 @@ func (s *Service[LK, LV, LQ]) SubToVolume(ctx context.Context, qh blobcache.Hand
 	if err != nil {
 		return err
 	}
-	if rights&blobcache.Action_VOLUME_SUB_TO < blobcache.Action_VOLUME_SUB_TO {
+	if !rights.Has(blobcache.Action_VOLUME_SUBSCRIBE) {
 		return blobcache.ErrPermission{
 			Handle:   volh,
 			Rights:   rights,
-			Requires: blobcache.Action_VOLUME_SUB_TO,
+			Requires: blobcache.Action_VOLUME_SUBSCRIBE,
 		}
 	}
 	switch rv := vol.backend.(type) {

--- a/src/internal/bcsys/bcsys.go
+++ b/src/internal/bcsys/bcsys.go
@@ -844,9 +844,46 @@ func (s *Service[LK, LV, LQ]) InspectVolume(ctx context.Context, h blobcache.Han
 func (s *Service[LK, LV, LQ]) BeginTx(ctx context.Context, volh blobcache.Handle, txspec blobcache.TxParams) (*blobcache.Handle, error) {
 	logctx.Debug(ctx, "begin", zap.String("method", "BeginTx"), zap.Stringer("oid", volh.OID))
 	defer logctx.Debug(ctx, "done", zap.String("method", "BeginTx"), zap.Stringer("oid", volh.OID))
-	vol, _, err := s.resolveVol(ctx, volh)
+	if err := txspec.Validate(); err != nil {
+		return nil, err
+	}
+	vol, rights, err := s.resolveVol(ctx, volh)
 	if err != nil {
 		return nil, err
+	}
+	if !rights.Has(blobcache.Action_VOLUME_BEGIN_TX) {
+		return nil, blobcache.ErrPermission{
+			Handle:   volh,
+			Rights:   rights,
+			Requires: blobcache.Action_VOLUME_BEGIN_TX,
+		}
+	}
+	if txspec.GCBlobs {
+		gcBlobRights := blobcache.ActionSet(blobcache.Action_VOLUME_TX_VISIT | blobcache.Action_VOLUME_TX_IS_VISITED)
+		if rights&gcBlobRights == 0 {
+			return nil, blobcache.ErrPermission{
+				Handle:   volh,
+				Rights:   rights,
+				Requires: gcBlobRights,
+			}
+		}
+	}
+	if txspec.Modify {
+		mutatingRights := blobcache.ActionSet(blobcache.Action_VOLUME_TX_SAVE |
+			blobcache.Action_VOLUME_TX_POST |
+			blobcache.Action_VOLUME_TX_DELETE |
+			blobcache.Action_VOLUME_TX_COPY_TO |
+			blobcache.Action_VOLUME_TX_LINK_FROM |
+			blobcache.Action_VOLUME_TX_UNLINK_FROM |
+			blobcache.Action_VOLUME_TX_VISIT |
+			blobcache.Action_VOLUME_TX_VISIT_LINKS)
+		if rights&mutatingRights == 0 {
+			return nil, blobcache.ErrPermission{
+				Handle:   volh,
+				Rights:   rights,
+				Requires: mutatingRights,
+			}
+		}
 	}
 	tx, err := vol.backend.BeginTx(ctx, txspec)
 	if err != nil {
@@ -865,7 +902,24 @@ func (s *Service[LK, LV, LQ]) BeginTx(ctx context.Context, volh blobcache.Handle
 	s.mu.Unlock()
 	createdAt := time.Now()
 	expiresAt := createdAt.Add(DefaultTxTTL)
-	h := s.handles.Create(txoid, blobcache.Action_ALL, createdAt, expiresAt)
+	txRights := blobcache.Action_ACK | blobcache.Action_TX_INSPECT
+	volTxRightsMask := blobcache.Action_VOLUME_TX_INSPECT |
+		blobcache.Action_VOLUME_TX_LOAD |
+		blobcache.Action_VOLUME_TX_SAVE |
+		blobcache.Action_VOLUME_TX_POST |
+		blobcache.Action_VOLUME_TX_GET |
+		blobcache.Action_VOLUME_TX_EXISTS |
+		blobcache.Action_VOLUME_TX_DELETE |
+		blobcache.Action_VOLUME_TX_COPY_FROM |
+		blobcache.Action_VOLUME_TX_COPY_TO |
+		blobcache.Action_VOLUME_TX_LINK_FROM |
+		blobcache.Action_VOLUME_TX_UNLINK_FROM |
+		blobcache.Action_VOLUME_TX_VISIT |
+		blobcache.Action_VOLUME_TX_IS_VISITED |
+		blobcache.Action_VOLUME_TX_VISIT_LINKS
+	txRights |= (rights & volTxRightsMask) >> 8
+	txRights |= (rights & blobcache.SharedAction(volTxRightsMask)) >> 8
+	h := s.handles.Create(txoid, txRights, createdAt, expiresAt)
 	return &h, nil
 }
 
@@ -1122,7 +1176,7 @@ func (s *Service[LK, LV, LQ]) Copy(ctx context.Context, txh blobcache.Handle, sr
 func (s *Service[LK, LV, LQ]) Visit(ctx context.Context, txh blobcache.Handle, cids []blobcache.CID) error {
 	logctx.Debug(ctx, "begin", zap.String("method", "Visit"), zap.Stringer("oid", txh.OID))
 	defer logctx.Debug(ctx, "done", zap.String("method", "Visit"), zap.Stringer("oid", txh.OID))
-	txn, err := s.resolveTx(txh, true, 0) // if a GC transaction was opened, then Visit it allowed.
+	txn, err := s.resolveTx(txh, true, blobcache.Action_TX_VISIT)
 	if err != nil {
 		return err
 	}
@@ -1135,7 +1189,7 @@ func (s *Service[LK, LV, LQ]) IsVisited(ctx context.Context, txh blobcache.Handl
 	if len(cids) != len(dst) {
 		return fmt.Errorf("cids and out must have the same length")
 	}
-	txn, err := s.resolveTx(txh, true, 0) // if a GC transaction was opened, then IsVisited is allowed.
+	txn, err := s.resolveTx(txh, true, blobcache.Action_TX_IS_VISITED)
 	if err != nil {
 		return err
 	}
@@ -1173,7 +1227,7 @@ func (s *Service[LK, LV, LQ]) Unlink(ctx context.Context, txh blobcache.Handle, 
 func (s *Service[LK, LV, LQ]) VisitLinks(ctx context.Context, txh blobcache.Handle, targets []blobcache.LinkToken) error {
 	logctx.Debug(ctx, "begin", zap.String("method", "VisitLinks"), zap.Stringer("oid", txh.OID))
 	defer logctx.Debug(ctx, "done", zap.String("method", "VisitLinks"), zap.Stringer("oid", txh.OID))
-	txn, err := s.resolveTx(txh, true, 0) // if a GC transaction was opened, then VisitLinks is allowed.
+	txn, err := s.resolveTx(txh, true, blobcache.Action_TX_VISIT_LINKS)
 	if err != nil {
 		return err
 	}

--- a/src/internal/blobcached/auth.go
+++ b/src/internal/blobcached/auth.go
@@ -81,11 +81,6 @@ const (
 	Action_CREATE_QUEUE  Action = "CREATE_QUEUE"
 )
 
-const (
-	action_CREATE_VOLUME blobcache.ActionSet = 1 << 62
-	action_CREATE_QUEUE  blobcache.ActionSet = 1 << 63
-)
-
 func (a Action) ToSet() blobcache.ActionSet {
 	switch a {
 	case Action_LOAD:
@@ -117,9 +112,9 @@ func (a Action) ToSet() blobcache.ActionSet {
 	case Action_VISIT_LINKS:
 		return blobcache.Action_VOLUME_TX_VISIT_LINKS
 	case Action_CREATE_VOLUME:
-		return action_CREATE_VOLUME
+		return 0
 	case Action_CREATE_QUEUE:
-		return action_CREATE_QUEUE
+		return 0
 	}
 	panic(a)
 }
@@ -421,7 +416,6 @@ func (p *Policy) OpenFiat(peer blobcache.NodeID, target blobcache.OID) blobcache
 	if rights&volTxRights != 0 {
 		rights |= blobcache.Action_VOLUME_BEGIN_TX
 	}
-	rights &^= action_CREATE_VOLUME | action_CREATE_QUEUE
 	return rights
 }
 
@@ -433,8 +427,7 @@ func (p *Policy) CanCreate(peer blobcache.NodeID) bool {
 	// check if any corresponding grant has CREATE in its action closure
 	for _, gi := range idenGrants {
 		grant := p.grants[gi]
-		rights := p.expandActionMember(grant.Action)
-		if rights&(action_CREATE_VOLUME|action_CREATE_QUEUE) != 0 {
+		if p.expandActionMemberCanCreate(grant.Action) {
 			return true
 		}
 	}
@@ -644,6 +637,36 @@ func (p *Policy) expandActionMember(m Member[Action]) blobcache.ActionSet {
 		return 0
 	}
 	return m.Unit.ToSet()
+}
+
+func (p *Policy) expandActionMemberCanCreate(m Member[Action]) bool {
+	seen := make(map[GroupName]bool)
+	var visit func(Member[Action]) bool
+	visit = func(mx Member[Action]) bool {
+		switch {
+		case mx.GroupRef != nil:
+			if seen[*mx.GroupRef] {
+				return false
+			}
+			seen[*mx.GroupRef] = true
+			for _, sub := range p.actions[*mx.GroupRef] {
+				if visit(sub) {
+					return true
+				}
+			}
+			return false
+		case mx.Unit != nil:
+			switch *mx.Unit {
+			case Action_CREATE_VOLUME, Action_CREATE_QUEUE:
+				return true
+			default:
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return visit(m)
 }
 
 // Management and enumeration helpers used by admin CLI

--- a/src/internal/blobcached/auth.go
+++ b/src/internal/blobcached/auth.go
@@ -71,38 +71,33 @@ const (
 	Action_LINK_FROM   Action = "LINK_FROM"
 	Action_LINK_TO     Action = "LINK_TO"
 	Action_UNLINK_FROM Action = "UNLINK_FROM"
-	Action_CLONE       Action = "CLONE"
 	Action_CREATE      Action = "CREATE"
 )
 
 func (a Action) ToSet() blobcache.ActionSet {
 	switch a {
 	case Action_LOAD:
-		return blobcache.Action_TX_LOAD
+		return blobcache.Action_VOLUME_TX_LOAD
 	case Action_SAVE:
-		return blobcache.Action_TX_SAVE
+		return blobcache.Action_VOLUME_TX_SAVE
 	case Action_POST:
-		return blobcache.Action_TX_POST
+		return blobcache.Action_VOLUME_TX_POST
 	case Action_GET:
-		return blobcache.Action_TX_GET
+		return blobcache.Action_VOLUME_TX_GET
 	case Action_EXISTS:
-		return blobcache.Action_TX_EXISTS
+		return blobcache.Action_VOLUME_TX_EXISTS
 	case Action_DELETE:
-		return blobcache.Action_TX_DELETE
+		return blobcache.Action_VOLUME_TX_DELETE
 	case Action_COPY_FROM:
-		return blobcache.Action_TX_COPY_FROM
+		return blobcache.Action_VOLUME_TX_COPY_FROM
 	case Action_COPY_TO:
-		return blobcache.Action_TX_COPY_TO
+		return blobcache.Action_VOLUME_TX_COPY_TO
 	case Action_LINK_FROM:
-		return blobcache.Action_TX_LINK_FROM
+		return blobcache.Action_VOLUME_TX_LINK_FROM
 	case Action_LINK_TO:
-		return blobcache.Action_TX_LINK_FROM
+		return blobcache.Action_VOLUME_TX_LINK_FROM
 	case Action_UNLINK_FROM:
-		return blobcache.Action_TX_UNLINK_FROM
-	case Action_CLONE:
-		return blobcache.Action_VOLUME_CLONE
-	case Action_CREATE:
-		return blobcache.Action_VOLUME_CREATE
+		return blobcache.Action_VOLUME_TX_UNLINK_FROM
 	}
 	panic(a)
 }
@@ -120,7 +115,6 @@ func AllActions() []Action {
 		Action_LINK_TO,
 		Action_UNLINK_FROM,
 
-		Action_CLONE,
 		Action_CREATE,
 	}
 }
@@ -149,8 +143,6 @@ func ParseAction(x []byte) (Action, error) {
 		return Action_LINK_TO, nil
 	case "UNLINK_FROM":
 		return Action_UNLINK_FROM, nil
-	case "CLONE":
-		return Action_CLONE, nil
 	case "CREATE":
 		return Action_CREATE, nil
 	}
@@ -377,8 +369,6 @@ func (p *Policy) OpenFiat(peer blobcache.NodeID, target blobcache.OID) blobcache
 		grant := p.grants[grantIndex]
 		rights |= p.expandActionMember(grant.Action)
 	}
-	// Open should never include Action_VOLUME_CREATE in the returned handle rights.
-	rights &^= blobcache.Action_VOLUME_CREATE
 	return rights
 }
 

--- a/src/internal/blobcached/auth.go
+++ b/src/internal/blobcached/auth.go
@@ -71,7 +71,19 @@ const (
 	Action_LINK_FROM   Action = "LINK_FROM"
 	Action_LINK_TO     Action = "LINK_TO"
 	Action_UNLINK_FROM Action = "UNLINK_FROM"
-	Action_CREATE      Action = "CREATE"
+	Action_VISIT       Action = "VISIT"
+	Action_IS_VISITED  Action = "IS_VISITED"
+	Action_VISIT_LINKS Action = "VISIT_LINKS"
+)
+
+const (
+	Action_CREATE_VOLUME Action = "CREATE"
+	Action_CREATE_QUEUE  Action = "CREATE_QUEUE"
+)
+
+const (
+	action_CREATE_VOLUME blobcache.ActionSet = 1 << 62
+	action_CREATE_QUEUE  blobcache.ActionSet = 1 << 63
 )
 
 func (a Action) ToSet() blobcache.ActionSet {
@@ -95,9 +107,19 @@ func (a Action) ToSet() blobcache.ActionSet {
 	case Action_LINK_FROM:
 		return blobcache.Action_VOLUME_TX_LINK_FROM
 	case Action_LINK_TO:
-		return blobcache.Action_VOLUME_TX_LINK_FROM
+		return blobcache.Action_VOLUME_LINK_TO
 	case Action_UNLINK_FROM:
 		return blobcache.Action_VOLUME_TX_UNLINK_FROM
+	case Action_VISIT:
+		return blobcache.Action_VOLUME_TX_VISIT
+	case Action_IS_VISITED:
+		return blobcache.Action_VOLUME_TX_IS_VISITED
+	case Action_VISIT_LINKS:
+		return blobcache.Action_VOLUME_TX_VISIT_LINKS
+	case Action_CREATE_VOLUME:
+		return action_CREATE_VOLUME
+	case Action_CREATE_QUEUE:
+		return action_CREATE_QUEUE
 	}
 	panic(a)
 }
@@ -107,6 +129,7 @@ func AllActions() []Action {
 		Action_LOAD,
 		Action_SAVE,
 		Action_POST,
+		Action_GET,
 		Action_EXISTS,
 		Action_DELETE,
 		Action_COPY_FROM,
@@ -114,8 +137,12 @@ func AllActions() []Action {
 		Action_LINK_FROM,
 		Action_LINK_TO,
 		Action_UNLINK_FROM,
+		Action_IS_VISITED,
+		Action_VISIT,
+		Action_VISIT_LINKS,
 
-		Action_CREATE,
+		Action_CREATE_VOLUME,
+		Action_CREATE_QUEUE,
 	}
 }
 
@@ -143,8 +170,16 @@ func ParseAction(x []byte) (Action, error) {
 		return Action_LINK_TO, nil
 	case "UNLINK_FROM":
 		return Action_UNLINK_FROM, nil
+	case "VISIT":
+		return Action_VISIT, nil
+	case "IS_VISITED":
+		return Action_IS_VISITED, nil
+	case "VISIT_LINKS":
+		return Action_VISIT_LINKS, nil
 	case "CREATE":
-		return Action_CREATE, nil
+		return Action_CREATE_VOLUME, nil
+	case "CREATE_QUEUE":
+		return Action_CREATE_QUEUE, nil
 	}
 	return "", fmt.Errorf("invalid action: %s", x)
 }
@@ -369,6 +404,24 @@ func (p *Policy) OpenFiat(peer blobcache.NodeID, target blobcache.OID) blobcache
 		grant := p.grants[grantIndex]
 		rights |= p.expandActionMember(grant.Action)
 	}
+	volTxRights := blobcache.Action_VOLUME_TX_INSPECT |
+		blobcache.Action_VOLUME_TX_LOAD |
+		blobcache.Action_VOLUME_TX_SAVE |
+		blobcache.Action_VOLUME_TX_POST |
+		blobcache.Action_VOLUME_TX_GET |
+		blobcache.Action_VOLUME_TX_EXISTS |
+		blobcache.Action_VOLUME_TX_DELETE |
+		blobcache.Action_VOLUME_TX_COPY_FROM |
+		blobcache.Action_VOLUME_TX_COPY_TO |
+		blobcache.Action_VOLUME_TX_LINK_FROM |
+		blobcache.Action_VOLUME_TX_UNLINK_FROM |
+		blobcache.Action_VOLUME_TX_VISIT |
+		blobcache.Action_VOLUME_TX_IS_VISITED |
+		blobcache.Action_VOLUME_TX_VISIT_LINKS
+	if rights&volTxRights != 0 {
+		rights |= blobcache.Action_VOLUME_BEGIN_TX
+	}
+	rights &^= action_CREATE_VOLUME | action_CREATE_QUEUE
 	return rights
 }
 
@@ -381,7 +434,7 @@ func (p *Policy) CanCreate(peer blobcache.NodeID) bool {
 	for _, gi := range idenGrants {
 		grant := p.grants[gi]
 		rights := p.expandActionMember(grant.Action)
-		if rights&Action_CREATE.ToSet() != 0 {
+		if rights&(action_CREATE_VOLUME|action_CREATE_QUEUE) != 0 {
 			return true
 		}
 	}

--- a/src/internal/blobcached/auth_test.go
+++ b/src/internal/blobcached/auth_test.go
@@ -283,7 +283,6 @@ func TestPolicy(t *testing.T) {
 				{Group: "all", Member: Unit(Action_LINK_FROM)},
 				{Group: "all", Member: Unit(Action_LINK_TO)},
 				{Group: "all", Member: Unit(Action_UNLINK_FROM)},
-				{Group: "all", Member: Unit(Action_CLONE)},
 				{Group: "all", Member: Unit(Action_CREATE)},
 			},
 			Objects: []Membership[ObjectSet]{
@@ -300,7 +299,7 @@ func TestPolicy(t *testing.T) {
 					Open: blobcache.Action_TX_LOAD | blobcache.Action_TX_SAVE | blobcache.Action_TX_POST |
 						blobcache.Action_TX_GET | blobcache.Action_TX_EXISTS | blobcache.Action_TX_DELETE |
 						blobcache.Action_TX_COPY_FROM | blobcache.Action_TX_COPY_TO |
-						blobcache.Action_TX_LINK_FROM | blobcache.Action_TX_UNLINK_FROM | blobcache.Action_VOLUME_CLONE,
+						blobcache.Action_TX_LINK_FROM | blobcache.Action_TX_UNLINK_FROM,
 					CanCreate: true,
 				},
 			},

--- a/src/internal/blobcached/auth_test.go
+++ b/src/internal/blobcached/auth_test.go
@@ -236,7 +236,7 @@ func TestPolicy(t *testing.T) {
 				{Subject: Unit(Everyone), Action: Unit(Action_GET), Object: Unit(ObjectSet{ByOID: &vol1})},
 			},
 			Checks: []Check{
-				{Peer: peer1, Target: vol1, CanConnect: true, Open: blobcache.Action_TX_GET, CanCreate: false},
+				{Peer: peer1, Target: vol1, CanConnect: true, Open: blobcache.Action_VOLUME_BEGIN_TX | blobcache.Action_VOLUME_TX_GET, CanCreate: false},
 			},
 		},
 		{
@@ -248,7 +248,7 @@ func TestPolicy(t *testing.T) {
 				{Group: "look", Member: Unit(Action_GET)},
 				{Group: "touch", Member: GroupRef[Action]("look")},
 				{Group: "touch", Member: Unit(Action_SAVE)},
-				{Group: "touch", Member: Unit(Action_CREATE)},
+				{Group: "touch", Member: Unit(Action_CREATE_VOLUME)},
 			},
 			Objects: []Membership[ObjectSet]{
 				{Group: "vols", Member: Unit(ObjectSet{ByOID: &vol1})},
@@ -261,7 +261,7 @@ func TestPolicy(t *testing.T) {
 					Peer:       peer1,
 					Target:     vol1,
 					CanConnect: true,
-					Open:       blobcache.Action_TX_GET | blobcache.Action_TX_SAVE,
+					Open:       blobcache.Action_VOLUME_BEGIN_TX | blobcache.Action_VOLUME_TX_GET | blobcache.Action_VOLUME_TX_SAVE,
 					CanCreate:  true,
 				},
 			},
@@ -283,7 +283,7 @@ func TestPolicy(t *testing.T) {
 				{Group: "all", Member: Unit(Action_LINK_FROM)},
 				{Group: "all", Member: Unit(Action_LINK_TO)},
 				{Group: "all", Member: Unit(Action_UNLINK_FROM)},
-				{Group: "all", Member: Unit(Action_CREATE)},
+				{Group: "all", Member: Unit(Action_CREATE_VOLUME)},
 			},
 			Objects: []Membership[ObjectSet]{
 				{Group: "all", Member: Unit(ObjectSet{ByOID: &vol1})},
@@ -296,10 +296,11 @@ func TestPolicy(t *testing.T) {
 					Peer:       peer1,
 					Target:     vol1,
 					CanConnect: true,
-					Open: blobcache.Action_TX_LOAD | blobcache.Action_TX_SAVE | blobcache.Action_TX_POST |
-						blobcache.Action_TX_GET | blobcache.Action_TX_EXISTS | blobcache.Action_TX_DELETE |
-						blobcache.Action_TX_COPY_FROM | blobcache.Action_TX_COPY_TO |
-						blobcache.Action_TX_LINK_FROM | blobcache.Action_TX_UNLINK_FROM,
+					Open: blobcache.Action_VOLUME_BEGIN_TX | blobcache.Action_VOLUME_LINK_TO |
+						blobcache.Action_VOLUME_TX_LOAD | blobcache.Action_VOLUME_TX_SAVE | blobcache.Action_VOLUME_TX_POST |
+						blobcache.Action_VOLUME_TX_GET | blobcache.Action_VOLUME_TX_EXISTS | blobcache.Action_VOLUME_TX_DELETE |
+						blobcache.Action_VOLUME_TX_COPY_FROM | blobcache.Action_VOLUME_TX_COPY_TO |
+						blobcache.Action_VOLUME_TX_LINK_FROM | blobcache.Action_VOLUME_TX_UNLINK_FROM,
 					CanCreate: true,
 				},
 			},

--- a/src/schema/bcgit/remote_test.go
+++ b/src/schema/bcgit/remote_test.go
@@ -40,7 +40,7 @@ func TestLsRemote(t *testing.T) {
 	ep, err := bc.Endpoint(ctx)
 	require.NoError(t, err)
 	u := blobcache.URL{
-		Node: ep.Peer,
+		Node: ep.Node,
 		Base: te.Volume.OID,
 	}
 
@@ -138,7 +138,7 @@ func setup(t testing.TB) testEnv {
 		Service: bc,
 		Volume:  *gitVol,
 		URL: blobcache.URL{
-			Node: ep.Peer,
+			Node: ep.Node,
 			Base: gitVol.OID,
 		},
 	}


### PR DESCRIPTION
- Changes how Volume and Tx actions are structured.
- All objects have ACK and INSPECT in the least significant bits
- Volumes now have their own operations in the low byte, with the high 24 bits reserved for Tx operations.
- Fixes ShareOut and Link to respect the share mask