### PR TITLE
bcp: CreateVolume and CreateQueue take Host Endpoint

### DIFF
--- a/client/rs/src/types.rs
+++ b/client/rs/src/types.rs
@@ -365,26 +365,66 @@ pub struct Endpoint {
 
 impl Endpoint {
     pub fn from_bcp_bytes(data: &[u8]) -> Result<Self, Error> {
-        if data.len() < NODE_ID_SIZE + 18 {
+        if data.len() < NODE_ID_SIZE {
             return Err(Error::InvalidEndpoint(format!("too short {}", data.len())));
         }
         let mut peer = [0u8; NODE_ID_SIZE];
         peer.copy_from_slice(&data[..NODE_ID_SIZE]);
-        let ap = &data[NODE_ID_SIZE..NODE_ID_SIZE + 18];
-        let ip_port = if ap[6..].iter().all(|b| *b == 0) {
-            let port = u16::from_le_bytes([ap[4], ap[5]]);
-            format!("{}.{}.{}.{}:{port}", ap[0], ap[1], ap[2], ap[3])
-        } else {
-            let mut octets = [0u8; 16];
-            octets.copy_from_slice(&ap[..16]);
-            let port = u16::from_le_bytes([ap[16], ap[17]]);
-            let ip = std::net::Ipv6Addr::from(octets);
-            format!("[{ip}]:{port}")
+        let ap = &data[NODE_ID_SIZE..];
+        let ip_port = match ap.len() {
+            0 => String::new(),
+            6 => {
+                let port = u16::from_le_bytes([ap[4], ap[5]]);
+                let ip = std::net::Ipv4Addr::new(ap[0], ap[1], ap[2], ap[3]);
+                format!("{ip}:{port}")
+            }
+            n if n >= 18 => {
+                let port = u16::from_le_bytes([ap[n - 2], ap[n - 1]]);
+                let addr = &ap[..n - 2];
+                if addr.len() < 16 {
+                    return Err(Error::InvalidEndpoint(format!(
+                        "invalid addr bytes {}",
+                        addr.len()
+                    )));
+                }
+                let mut octets = [0u8; 16];
+                octets.copy_from_slice(&addr[..16]);
+                let ip = std::net::Ipv6Addr::from(octets);
+                if addr.len() == 16 {
+                    format!("[{ip}]:{port}")
+                } else {
+                    let zone = String::from_utf8_lossy(&addr[16..]);
+                    format!("[{ip}%{zone}]:{port}")
+                }
+            }
+            n => {
+                return Err(Error::InvalidEndpoint(format!(
+                    "invalid endpoint addr-port length {}",
+                    n
+                )));
+            }
         };
         Ok(Self {
             node: NodeID(peer),
             ip_port,
         })
+    }
+
+    pub fn marshal_bcp(&self, out: &mut Vec<u8>) -> Result<(), Error> {
+        out.extend_from_slice(&self.node.0);
+        if self.ip_port.is_empty() {
+            return Ok(());
+        }
+        let sock: std::net::SocketAddr = self
+            .ip_port
+            .parse()
+            .map_err(|_| Error::InvalidEndpoint(self.ip_port.clone()))?;
+        match sock.ip() {
+            std::net::IpAddr::V4(v4) => out.extend_from_slice(&v4.octets()),
+            std::net::IpAddr::V6(v6) => out.extend_from_slice(&v6.octets()),
+        }
+        out.extend_from_slice(&sock.port().to_le_bytes());
+        Ok(())
     }
 }
 

--- a/client/rs/src/unix.rs
+++ b/client/rs/src/unix.rs
@@ -334,8 +334,26 @@ impl Service for UnixClient {
         Ok(())
     }
 
-    fn create_queue(&self, _host: Option<&Endpoint>, spec: &QueueSpec) -> Result<Handle, Error> {
-        let req = serde_json::to_vec(spec)?;
+    fn create_queue(&self, host: Option<&Endpoint>, spec: &QueueSpec) -> Result<Handle, Error> {
+        let mut req = Vec::new();
+        let mut host_data = Vec::new();
+        match host {
+            Some(host) => host.marshal_bcp(&mut host_data)?,
+            None => host_data.extend_from_slice(&[0u8; NODE_ID_SIZE]),
+        }
+        if host_data.len() > u16::MAX as usize {
+            return Err(Error::InvalidEndpoint("host endpoint too large".to_string()));
+        }
+        req.extend_from_slice(&(host_data.len() as u16).to_le_bytes());
+        req.extend_from_slice(&host_data);
+
+        let spec_data = serde_json::to_vec(spec)?;
+        if spec_data.len() > u16::MAX as usize {
+            return Err(Error::InvalidMessage("queue spec too large".to_string()));
+        }
+        req.extend_from_slice(&(spec_data.len() as u16).to_le_bytes());
+        req.extend_from_slice(&spec_data);
+
         let body = self.ask(bcp::MT_QUEUE_CREATE, &req)?;
         Handle::unmarshal(&body)
     }

--- a/client/rs/src/unix.rs
+++ b/client/rs/src/unix.rs
@@ -122,8 +122,26 @@ impl Service for UnixClient {
         Handle::unmarshal(&body[..HANDLE_SIZE])
     }
 
-    fn create_volume(&self, _host: Option<&Endpoint>, spec: &VolumeSpec) -> Result<Handle, Error> {
-        let req = serde_json::to_vec(spec)?;
+    fn create_volume(&self, host: Option<&Endpoint>, spec: &VolumeSpec) -> Result<Handle, Error> {
+        let mut req = Vec::new();
+        let mut host_data = Vec::new();
+        match host {
+            Some(host) => host.marshal_bcp(&mut host_data)?,
+            None => host_data.extend_from_slice(&[0u8; NODE_ID_SIZE]),
+        }
+        if host_data.len() > u16::MAX as usize {
+            return Err(Error::InvalidEndpoint("host endpoint too large".to_string()));
+        }
+        req.extend_from_slice(&(host_data.len() as u16).to_le_bytes());
+        req.extend_from_slice(&host_data);
+
+        let spec_data = serde_json::to_vec(spec)?;
+        if spec_data.len() > u16::MAX as usize {
+            return Err(Error::InvalidMessage("volume spec too large".to_string()));
+        }
+        req.extend_from_slice(&(spec_data.len() as u16).to_le_bytes());
+        req.extend_from_slice(&spec_data);
+
         let body = self.ask(bcp::MT_CREATE_VOLUME, &req)?;
         if body.len() < HANDLE_SIZE {
             return Err(Error::InvalidMessage(

--- a/src/bcipc/bcipc.go
+++ b/src/bcipc/bcipc.go
@@ -3,6 +3,7 @@ package bcipc
 
 import (
 	"context"
+	"fmt"
 	"net"
 
 	"blobcache.io/blobcache/src/blobcache"
@@ -20,6 +21,9 @@ type clientTransport struct {
 }
 
 func (ct *clientTransport) Ask(ctx context.Context, remEp blobcache.Endpoint, req bcp.Message, resp *bcp.Message) error {
+	if remEp != (blobcache.Endpoint{}) {
+		return fmt.Errorf("bcipc: endpoint must be zeroed in call to Ask.  HAVE: %v", remEp)
+	}
 	conn, err := ct.pool.Take(ctx)
 	if err != nil {
 		return err

--- a/src/bcipc/client.go
+++ b/src/bcipc/client.go
@@ -89,27 +89,28 @@ func (c *Client) OpenFrom(ctx context.Context, base blobcache.Handle, token blob
 }
 
 func (c *Client) BeginTx(ctx context.Context, volh blobcache.Handle, txp blobcache.TxParams) (*blobcache.Handle, error) {
-	h, info, err := bcp.BeginTx(ctx, &c.tp, blobcache.Endpoint{}, volh, txp)
+	resp, err := bcp.BeginTx(ctx, &c.tp, blobcache.Endpoint{}, bcp.BeginTxReq{
+		Volume: volh,
+		Params: txp,
+	})
 	if err != nil {
 		return nil, err
 	}
-	c.cache.Add(h.OID, info)
-	return h, nil
+	c.cache.Add(resp.Tx.OID, &resp.Info)
+	return &resp.Tx, nil
 }
 
 // CreateVolume creates a new volume.
 func (c *Client) CreateVolume(ctx context.Context, host *blobcache.Endpoint, vspec blobcache.VolumeSpec) (*blobcache.Handle, error) {
+	var host2 blobcache.Endpoint
 	if host != nil {
-		ep, err := c.Endpoint(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if *host != ep {
-			return nil, fmt.Errorf("bcipc: caller cannot be different from the node ID")
-		}
+		host2 = *host
 	}
-	vol, _, err := bcp.CreateVolume(ctx, &c.tp, blobcache.Endpoint{}, vspec)
-	return vol, err
+	resp, err := bcp.CreateVolume(ctx, &c.tp, blobcache.Endpoint{}, bcp.CreateVolumeReq{
+		Host: host2,
+		Spec: vspec,
+	})
+	return &resp.Handle, err
 }
 
 // InspectVolume returns info about a Volume.

--- a/src/bcipc/client.go
+++ b/src/bcipc/client.go
@@ -198,8 +198,19 @@ func (c *Client) VisitLinks(ctx context.Context, tx blobcache.Handle, targets []
 	return bcp.VisitLinks(ctx, &c.tp, blobcache.Endpoint{}, tx, targets)
 }
 
-func (c *Client) CreateQueue(ctx context.Context, _ *blobcache.Endpoint, qspec blobcache.QueueSpec) (*blobcache.Handle, error) {
-	return bcp.CreateQueue(ctx, &c.tp, blobcache.Endpoint{}, qspec)
+func (c *Client) CreateQueue(ctx context.Context, host *blobcache.Endpoint, qspec blobcache.QueueSpec) (*blobcache.Handle, error) {
+	var host2 blobcache.Endpoint
+	if host != nil {
+		host2 = *host
+	}
+	resp, err := bcp.CreateQueue(ctx, &c.tp, blobcache.Endpoint{}, bcp.CreateQueueReq{
+		Host: host2,
+		Spec: qspec,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Handle, nil
 }
 
 func (c *Client) InspectQueue(ctx context.Context, qh blobcache.Handle) (blobcache.QueueInfo, error) {

--- a/src/bcipc/client.go
+++ b/src/bcipc/client.go
@@ -108,7 +108,8 @@ func (c *Client) CreateVolume(ctx context.Context, host *blobcache.Endpoint, vsp
 			return nil, fmt.Errorf("bcipc: caller cannot be different from the node ID")
 		}
 	}
-	return bcp.CreateVolume(ctx, &c.tp, blobcache.Endpoint{}, vspec)
+	vol, _, err := bcp.CreateVolume(ctx, &c.tp, blobcache.Endpoint{}, vspec)
+	return vol, err
 }
 
 // InspectVolume returns info about a Volume.

--- a/src/bcremote/bcremote.go
+++ b/src/bcremote/bcremote.go
@@ -148,7 +148,8 @@ func (s *Service) CreateVolume(ctx context.Context, host *blobcache.Endpoint, vs
 	if host != nil && *host != s.ep {
 		return nil, fmt.Errorf("bcremote: caller cannot be different from the node ID")
 	}
-	return bcp.CreateVolume(ctx, s.node, s.ep, vspec)
+	vol, _, err := bcp.CreateVolume(ctx, s.node, s.ep, vspec)
+	return vol, err
 }
 
 // InspectVolume returns info about a Volume.

--- a/src/bcremote/bcremote.go
+++ b/src/bcremote/bcremote.go
@@ -135,21 +135,28 @@ func (s *Service) OpenFrom(ctx context.Context, base blobcache.Handle, token blo
 }
 
 func (s *Service) BeginTx(ctx context.Context, volh blobcache.Handle, txp blobcache.TxParams) (*blobcache.Handle, error) {
-	h, info, err := bcp.BeginTx(ctx, s.node, s.ep, volh, txp)
+	resp, err := bcp.BeginTx(ctx, s.node, s.ep, bcp.BeginTxReq{
+		Volume: volh,
+		Params: txp,
+	})
 	if err != nil {
 		return nil, err
 	}
-	s.cache.Add(h.OID, info)
-	return h, nil
+	s.cache.Add(resp.Tx.OID, &resp.Info)
+	return &resp.Tx, nil
 }
 
 // CreateVolume creates a new volume.
 func (s *Service) CreateVolume(ctx context.Context, host *blobcache.Endpoint, vspec blobcache.VolumeSpec) (*blobcache.Handle, error) {
-	if host != nil && *host != s.ep {
-		return nil, fmt.Errorf("bcremote: caller cannot be different from the node ID")
+	var host2 blobcache.Endpoint
+	if host != nil {
+		host2 = *host
 	}
-	vol, _, err := bcp.CreateVolume(ctx, s.node, s.ep, vspec)
-	return vol, err
+	resp, err := bcp.CreateVolume(ctx, s.node, s.ep, bcp.CreateVolumeReq{
+		Host: host2,
+		Spec: vspec,
+	})
+	return &resp.Handle, err
 }
 
 // InspectVolume returns info about a Volume.

--- a/src/bcremote/bcremote.go
+++ b/src/bcremote/bcremote.go
@@ -245,7 +245,11 @@ func (s *Service) VisitLinks(ctx context.Context, tx blobcache.Handle, targets [
 }
 
 func (s *Service) CreateQueue(ctx context.Context, _ *blobcache.Endpoint, qspec blobcache.QueueSpec) (*blobcache.Handle, error) {
-	return bcp.CreateQueue(ctx, s.node, s.ep, qspec)
+	resp, err := bcp.CreateQueue(ctx, s.node, s.ep, bcp.CreateQueueReq{Spec: qspec})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Handle, nil
 }
 
 func (s *Service) InspectQueue(ctx context.Context, qh blobcache.Handle) (blobcache.QueueInfo, error) {

--- a/src/blobcache/blobcachetests/multinode.go
+++ b/src/blobcache/blobcachetests/multinode.go
@@ -1,6 +1,7 @@
 package blobcachetests
 
 import (
+	"net/netip"
 	"testing"
 
 	"blobcache.io/blobcache/src/blobcache"
@@ -9,7 +10,8 @@ import (
 )
 
 func TestMultiNode(t *testing.T, mk func(t testing.TB, n int) []blobcache.Service) {
-	t.Run("CreateVolumeRemote", func(t *testing.T) {
+	t.Run("OpenRemoteVolume", func(t *testing.T) {
+		t.Parallel()
 		ctx := testutil.Context(t)
 		svcs := mk(t, 2)
 		s1, s2 := svcs[0], svcs[1]
@@ -27,7 +29,30 @@ func TestMultiNode(t *testing.T, mk func(t testing.TB, n int) []blobcache.Servic
 		require.NoError(t, err)
 		require.NoError(t, s2.Abort(ctx, *tx))
 	})
+	t.Run("CreateVolumeOnRemote", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t)
+		svcs := mk(t, 2)
+		s1, s2 := svcs[0], svcs[1]
+		s1ep := Endpoint(t, s1)
+		s1ep.IPPort = netip.AddrPort{}
+
+		volh, err := s2.CreateVolume(ctx, &s1ep, defaultLocalSpec())
+		require.NoError(t, err)
+
+		volinfo, err := s2.InspectVolume(ctx, *volh)
+		require.NoError(t, err)
+
+		require.Nil(t, volinfo.Backend.Local)
+		require.NotNil(t, volinfo.Backend.Remote)
+		require.Equal(t, s1ep.Node, volinfo.Backend.Remote.Endpoint.Node)
+
+		tx, err := s2.BeginTx(ctx, *volh, blobcache.TxParams{})
+		require.NoError(t, err)
+		require.NoError(t, s2.Abort(ctx, *tx))
+	})
 	t.Run("Remote/Tx", func(t *testing.T) {
+		t.Parallel()
 		ctx := testutil.Context(t)
 		TxAPI(t, func(t testing.TB) (blobcache.Service, blobcache.Handle) {
 			svcs := mk(t, 2)
@@ -42,6 +67,7 @@ func TestMultiNode(t *testing.T, mk func(t testing.TB, n int) []blobcache.Servic
 		})
 	})
 	t.Run("Remote/Queue", func(t *testing.T) {
+		t.Parallel()
 		QueueAPI(t, func(t testing.TB) (blobcache.QueueAPI, blobcache.Handle) {
 			ctx := testutil.Context(t)
 			svcs := mk(t, 2)
@@ -62,6 +88,7 @@ func TestMultiNode(t *testing.T, mk func(t testing.TB, n int) []blobcache.Servic
 		})
 	})
 	t.Run("Remote/SubToVol", func(t *testing.T) {
+		t.Parallel()
 		TestVolumeSubscribe(t, func(t testing.TB) (blobcache.Service, blobcache.Handle, blobcache.Handle) {
 			ctx := testutil.Context(t)
 			svcs := mk(t, 2)

--- a/src/blobcache/volume.go
+++ b/src/blobcache/volume.go
@@ -188,32 +188,33 @@ type Endpoint struct {
 	IPPort netip.AddrPort `json:"ip_port"`
 }
 
-const EndpointSize = NodeIDSize + 16 + 2
-
+// Marshal marshals a variable length binary encoding
 func (e Endpoint) Marshal(out []byte) []byte {
 	out = append(out, e.Node[:]...)
 
-	ipaddrData, err := e.IPPort.AppendBinary(nil)
-	if err != nil {
-		panic(err)
+	if e.IPPort.IsValid() {
+		ipaddrData, err := e.IPPort.AppendBinary(nil)
+		if err != nil {
+			panic(err)
+		}
+		out = append(out, ipaddrData...)
 	}
-	for len(ipaddrData) < 16+2 { // 16 bytes for the IP address, 2 bytes for the port
-		ipaddrData = append(ipaddrData, 0)
-	}
-	out = append(out, ipaddrData...)
 	return out
 }
 
+// Unmarshal gets an endpoint from the format produced by Marshal
 func (e *Endpoint) Unmarshal(data []byte) error {
-	if len(data) < NodeIDSize+16+2 {
+	if len(data) < NodeIDSize {
 		return fmt.Errorf("too small to be endpoint")
 	}
 	e.Node, data = NodeID(data[:NodeIDSize]), data[NodeIDSize:]
-	var ipaddr netip.AddrPort
-	if err := ipaddr.UnmarshalBinary(data[:16+2]); err != nil {
-		return err
+	if len(data) != 0 {
+		var ipaddr netip.AddrPort
+		if err := ipaddr.UnmarshalBinary(data); err != nil {
+			return err
+		}
+		e.IPPort = ipaddr
 	}
-	e.IPPort = ipaddr
 	return nil
 }
 
@@ -223,16 +224,19 @@ func (e Endpoint) String() string {
 
 func ParseEndpoint(s string) (Endpoint, error) {
 	parts := strings.SplitN(s, ":", 2)
-	if len(parts) != 2 {
+	if len(parts) == 0 {
 		return Endpoint{}, fmt.Errorf("invalid endpoint: %s", s)
 	}
 	peer, err := inet256.ParseAddrBase64([]byte(parts[0]))
 	if err != nil {
 		return Endpoint{}, err
 	}
-	ap, err := netip.ParseAddrPort(parts[1])
-	if err != nil {
-		return Endpoint{}, err
+	var ap netip.AddrPort
+	if len(parts) >= 2 {
+		ap, err = netip.ParseAddrPort(parts[1])
+		if err != nil {
+			return Endpoint{}, err
+		}
 	}
 	return Endpoint{
 		Node:   peer,
@@ -347,12 +351,10 @@ func (v VolumeBackend[T]) String() string {
 	return sb.String()
 }
 
+// Validate checks that only one backend is set
 func (v *VolumeBackend[T]) Validate() (err error) {
 	var count int
 	if v.Local != nil {
-		if err := v.Local.Validate(); err != nil {
-			return err
-		}
 		count++
 	}
 	if v.Remote != nil {
@@ -365,9 +367,6 @@ func (v *VolumeBackend[T]) Validate() (err error) {
 		count++
 	}
 	if v.Vault != nil {
-		if err := v.Vault.Validate(); err != nil {
-			return err
-		}
 		count++
 	}
 

--- a/src/blobcachecmd/root.go
+++ b/src/blobcachecmd/root.go
@@ -49,6 +49,7 @@ var rootCmd = star.NewDir(
 		"mkvol.remote": mkVolRemoteCmd,
 		"mkvol.vault":  mkVolVaultCmd,
 		"mkvol.git":    mkVolGitCmd,
+		"vspec.local":  vspecLocalCmd,
 		"ivol":         ivolCmd,
 		"open-fiat":    openFiatCmd,
 		"open-from":    openFromCmd,

--- a/src/blobcachecmd/volume.go
+++ b/src/blobcachecmd/volume.go
@@ -168,25 +168,16 @@ var vspecLocalCmd = star.Command{
 
 func localSpec(c star.Context) blobcache.VolumeSpec {
 	spec := blobcache.DefaultLocalSpec()
-	ha, ok := hashAlgoParam.LoadOpt(c)
-	if ok {
+	if ha, ok := hashAlgoParam.LoadOpt(c); ok {
 		spec.Local.HashAlgo = ha
 	}
-	maxSize, ok := maxSizeParam.LoadOpt(c)
-	if ok {
+	if maxSize, ok := maxSizeParam.LoadOpt(c); ok {
 		spec.Local.MaxSize = maxSize
 	}
-	schema, ok := schemaParam.LoadOpt(c)
-	if ok {
+	if schema, ok := schemaParam.LoadOpt(c); ok {
 		spec.Local.Schema = schema
 	}
-	return blobcache.VolumeSpec{
-		Local: &blobcache.VolumeBackend_Local{
-			HashAlgo: ha,
-			MaxSize:  maxSize,
-			Schema:   schema,
-		},
-	}
+	return spec
 }
 
 var ivolCmd = star.Command{

--- a/src/blobcachecmd/volume.go
+++ b/src/blobcachecmd/volume.go
@@ -50,6 +50,7 @@ var mkVolLocalCmd = star.Command{
 	},
 	Flags: map[string]star.Flag{
 		"host":     hostParam,
+		"schema":   schemaParam,
 		"hash":     hashAlgoParam,
 		"max-size": maxSizeParam,
 	},
@@ -60,13 +61,7 @@ var mkVolLocalCmd = star.Command{
 			return err
 		}
 		host, _ := hostParam.LoadOpt(c)
-		spec := blobcache.DefaultLocalSpec()
-		if ha, ok := hashAlgoParam.LoadOpt(c); ok {
-			spec.Local.HashAlgo = ha
-		}
-		if maxSize, ok := maxSizeParam.LoadOpt(c); ok {
-			spec.Local.MaxSize = maxSize
-		}
+		spec := localSpec(c)
 		h, err := s.CreateVolume(c.Context, host, spec)
 		if err != nil {
 			return err
@@ -153,18 +148,45 @@ var mkVolGitCmd = star.Command{
 	},
 }
 
-var awaitCmd = star.Command{
-	Metadata: star.Metadata{
-		Short: "await for a volume to change",
+var vspecLocalCmd = star.Command{
+	Metadata: star.Metadata{Short: "print a volume spec, suitable for piping to mkvol"},
+	Flags: map[string]star.Flag{
+		"schema":   schemaParam,
+		"hash":     hashAlgoParam,
+		"max-size": maxSizeParam,
 	},
-	Pos: []star.Positional{volHParam},
 	F: func(c star.Context) error {
-		_, err := openService(c)
+		vspec := localSpec(c)
+		data, err := json.MarshalIndent(vspec, "", "  ")
 		if err != nil {
-			return err
+			return nil
 		}
-		return fmt.Errorf("not yet implemented")
+		_, err = c.StdOut.Write(data)
+		return err
 	},
+}
+
+func localSpec(c star.Context) blobcache.VolumeSpec {
+	spec := blobcache.DefaultLocalSpec()
+	ha, ok := hashAlgoParam.LoadOpt(c)
+	if ok {
+		spec.Local.HashAlgo = ha
+	}
+	maxSize, ok := maxSizeParam.LoadOpt(c)
+	if ok {
+		spec.Local.MaxSize = maxSize
+	}
+	schema, ok := schemaParam.LoadOpt(c)
+	if ok {
+		spec.Local.Schema = schema
+	}
+	return blobcache.VolumeSpec{
+		Local: &blobcache.VolumeBackend_Local{
+			HashAlgo: ha,
+			MaxSize:  maxSize,
+			Schema:   schema,
+		},
+	}
 }
 
 var ivolCmd = star.Command{
@@ -322,5 +344,14 @@ var linkTokenParam = star.Required[blobcache.LinkToken]{
 			return blobcache.LinkToken{}, err
 		}
 		return ltok, nil
+	},
+}
+
+var schemaParam = star.Optional[blobcache.SchemaSpec]{
+	ID: "schema",
+	Parse: func(x string) (blobcache.SchemaSpec, error) {
+		var ret blobcache.SchemaSpec
+		err := json.Unmarshal([]byte(x), &ret)
+		return ret, err
 	},
 }

--- a/src/internal/backend/remotebe/peer.go
+++ b/src/internal/backend/remotebe/peer.go
@@ -35,16 +35,8 @@ func NewPeerSystem(inner *System, locator PeerLocator) PeerSystem {
 }
 
 func (ps *PeerSystem) VolumeUp(ctx context.Context, p PeerParams) (*Volume, error) {
-	if ps.locator == nil {
-		return nil, fmt.Errorf("bcpeer: no PeerLocator configured")
-	}
 	const dialTimeout = 3 * time.Second
-	var lastErr error
-	for addr := range ps.locator.WhereIs(ctx, p.Peer) {
-		ep := blobcache.Endpoint{
-			Node:   p.Peer,
-			IPPort: addr,
-		}
+	return withEndpoint(ctx, ps.locator, p.Peer, func(ep blobcache.Endpoint) (*Volume, error) {
 		dialCtx, cf := context.WithTimeout(ctx, dialTimeout)
 		defer cf()
 		vol, err := ps.inner.VolumeUp(dialCtx, Params{
@@ -52,21 +44,43 @@ func (ps *PeerSystem) VolumeUp(ctx context.Context, p PeerParams) (*Volume, erro
 			Volume:   p.Volume,
 			HashAlgo: p.HashAlgo,
 		})
-		cf()
-		if err == nil {
-			logctx.Info(ctx, "found peer", zap.Stringer("peer", p.Peer))
-			return vol, nil
-		} else {
-			logctx.Warn(ctx, "error looking for peer", zap.Stringer("peer", p.Peer), zap.Error(err))
-			lastErr = err
-		}
-	}
-	if lastErr != nil {
-		return nil, fmt.Errorf("bcpeer: could not reach peer %s: %w", p.Peer, lastErr)
-	}
-	return nil, fmt.Errorf("bcpeer: could not reach peer %s", p.Peer)
+		return vol, err
+	})
 }
 
 func (ps *PeerSystem) VolumeDestroy(ctx context.Context, vol *Volume) error {
 	return ps.inner.VolumeDestroy(ctx, vol)
+}
+
+// Create creates a new volume on the remote
+func (ps *PeerSystem) CreateVolume(ctx context.Context, peer blobcache.NodeID, vspec blobcache.VolumeSpec) (*Volume, error) {
+	return withEndpoint(ctx, ps.locator, peer, func(ep blobcache.Endpoint) (*Volume, error) {
+		return ps.inner.CreateVolume(ctx, ep, vspec)
+	})
+}
+
+func withEndpoint[T any](ctx context.Context, loc PeerLocator, peer blobcache.NodeID, fn func(blobcache.Endpoint) (T, error)) (T, error) {
+	var ret T
+	if loc == nil {
+		return ret, fmt.Errorf("bcpeer: no PeerLocator configured")
+	}
+	const dialTimeout = 3 * time.Second
+	var lastErr error
+	for addr := range loc.WhereIs(ctx, peer) {
+		ep := blobcache.Endpoint{
+			Node:   peer,
+			IPPort: addr,
+		}
+		val, err := fn(ep)
+		if err == nil {
+			logctx.Info(ctx, "found peer", zap.Stringer("peer", peer), zap.Stringer("ip_port", addr))
+			return val, nil
+		}
+		logctx.Warn(ctx, "error looking for peer", zap.Stringer("peer", peer), zap.Error(err))
+		lastErr = err
+	}
+	if lastErr != nil {
+		return ret, fmt.Errorf("bcpeer: could not reach peer %s: %w", peer, lastErr)
+	}
+	return ret, fmt.Errorf("bcpeer: could not reach peer %s", peer)
 }

--- a/src/internal/backend/remotebe/system.go
+++ b/src/internal/backend/remotebe/system.go
@@ -75,6 +75,27 @@ func (sys *System) VolumeDown(ctx context.Context, vol *Volume) error {
 	return nil
 }
 
+func (sys *System) CreateVolume(ctx context.Context, ep blobcache.Endpoint, vspec blobcache.VolumeSpec) (*Volume, error) {
+	hashAlgo := vspec.Config().HashAlgo
+	node := sys.node.Load()
+	if node == nil {
+		return nil, fmt.Errorf("bcremote: cannot create remote volume, no node")
+	}
+	h, volinfo, err := bcp.CreateVolume(ctx, node, ep, vspec)
+	if err != nil {
+		return nil, err
+	}
+	vol := NewVolume(sys, node, ep, *h, volinfo)
+	sys.mu.Lock()
+	defer sys.mu.Unlock()
+	p := Params{Endpoint: ep, Volume: h.OID, HashAlgo: hashAlgo}
+	if _, exists := sys.remote[p]; exists {
+		return nil, fmt.Errorf("peer %v reused OID in reply to CreateVolume", ep.Node, h.OID)
+	}
+	sys.remote[p] = vol
+	return vol, nil
+}
+
 func (sys *System) VolumeDestroy(ctx context.Context, vol *Volume) error {
 	// no way for us to destroy a remote volume
 	return nil

--- a/src/internal/backend/remotebe/system.go
+++ b/src/internal/backend/remotebe/system.go
@@ -109,15 +109,17 @@ func (sys *System) CreateQueue(ctx context.Context, ep blobcache.Endpoint, qspec
 	if node == nil {
 		return nil, nil, fmt.Errorf("bcremote: cannot create remote queue, no node")
 	}
-	qh, err := bcp.CreateQueue(ctx, node, ep, qspec)
+	resp, err := bcp.CreateQueue(ctx, node, ep, bcp.CreateQueueReq{
+		Spec: qspec,
+	})
 	if err != nil {
 		return nil, nil, err
 	}
-	info, err := bcp.InspectQueue(ctx, node, ep, *qh)
+	info, err := bcp.InspectQueue(ctx, node, ep, resp.Handle)
 	if err != nil {
 		return nil, nil, err
 	}
-	return NewQueue(sys, node, ep, *qh, info.Config), &info, nil
+	return NewQueue(sys, node, ep, resp.Handle, info.Config), &info, nil
 }
 
 // QueueUp opens an existing remote queue and returns a local proxy.

--- a/src/internal/backend/remotebe/system.go
+++ b/src/internal/backend/remotebe/system.go
@@ -81,16 +81,18 @@ func (sys *System) CreateVolume(ctx context.Context, ep blobcache.Endpoint, vspe
 	if node == nil {
 		return nil, fmt.Errorf("bcremote: cannot create remote volume, no node")
 	}
-	h, volinfo, err := bcp.CreateVolume(ctx, node, ep, vspec)
+	// The host cannot be set to non-zero when using bcnet.Node
+	resp, err := bcp.CreateVolume(ctx, node, ep, bcp.CreateVolumeReq{Spec: vspec})
 	if err != nil {
 		return nil, err
 	}
-	vol := NewVolume(sys, node, ep, *h, volinfo)
+	h := resp.Handle
+	vol := NewVolume(sys, node, ep, resp.Handle, &resp.Info)
 	sys.mu.Lock()
 	defer sys.mu.Unlock()
 	p := Params{Endpoint: ep, Volume: h.OID, HashAlgo: hashAlgo}
 	if _, exists := sys.remote[p]; exists {
-		return nil, fmt.Errorf("peer %v reused OID in reply to CreateVolume", ep.Node, h.OID)
+		return nil, fmt.Errorf("peer %v reused OID %v  in reply to CreateVolume", ep.Node, h.OID)
 	}
 	sys.remote[p] = vol
 	return vol, nil

--- a/src/internal/backend/remotebe/volume.go
+++ b/src/internal/backend/remotebe/volume.go
@@ -51,15 +51,15 @@ func (v *Volume) Handle() blobcache.Handle {
 }
 
 func (v *Volume) BeginTx(ctx context.Context, spec blobcache.TxParams) (backend.Tx, error) {
-	txh, info, err := bcp.BeginTx(ctx, v.n, v.ep, v.h, spec)
+	resp, err := bcp.BeginTx(ctx, v.n, v.ep, bcp.BeginTxReq{Volume: v.h, Params: spec})
 	if err != nil {
 		return nil, err
 	}
 	return &Tx{
 		vol:    v,
 		params: spec,
-		h:      *txh,
-		info:   info,
+		h:      resp.Tx,
+		info:   &resp.Info,
 	}, nil
 }
 

--- a/src/internal/bcp/bcp.go
+++ b/src/internal/bcp/bcp.go
@@ -105,20 +105,16 @@ func OpenFrom(ctx context.Context, tp Asker, ep blobcache.Endpoint, base blobcac
 	return &resp.Handle, &resp.Info, nil
 }
 
-func CreateVolume(ctx context.Context, tp Asker, ep blobcache.Endpoint, vspec blobcache.VolumeSpec) (*blobcache.Handle, *blobcache.VolumeInfo, error) {
+func CreateVolume(ctx context.Context, tp Asker, ep blobcache.Endpoint, req CreateVolumeReq) (CreateVolumeResp, error) {
 	var resp CreateVolumeResp
-	if err := doAsk(ctx, tp, ep, MT_CREATE_VOLUME, CreateVolumeReq{Spec: vspec}, &resp); err != nil {
-		return nil, nil, err
-	}
-	return &resp.Handle, &resp.Info, nil
+	err := doAsk(ctx, tp, ep, MT_CREATE_VOLUME, req, &resp)
+	return resp, err
 }
 
-func BeginTx(ctx context.Context, tp Asker, ep blobcache.Endpoint, volh blobcache.Handle, txp blobcache.TxParams) (*blobcache.Handle, *blobcache.TxInfo, error) {
+func BeginTx(ctx context.Context, tp Asker, ep blobcache.Endpoint, req BeginTxReq) (BeginTxResp, error) {
 	var resp BeginTxResp
-	if err := doAsk(ctx, tp, ep, MT_VOLUME_BEGIN_TX, BeginTxReq{Volume: volh, Params: txp}, &resp); err != nil {
-		return nil, nil, err
-	}
-	return &resp.Tx, &resp.Info, nil
+	err := doAsk(ctx, tp, ep, MT_VOLUME_BEGIN_TX, req, &resp)
+	return resp, err
 }
 
 func InspectTx(ctx context.Context, tp Asker, ep blobcache.Endpoint, tx blobcache.Handle) (*blobcache.TxInfo, error) {

--- a/src/internal/bcp/bcp.go
+++ b/src/internal/bcp/bcp.go
@@ -312,12 +312,10 @@ func InspectVolume(ctx context.Context, tp Asker, ep blobcache.Endpoint, vol blo
 	return &resp.Info, nil
 }
 
-func CreateQueue(ctx context.Context, tp Asker, ep blobcache.Endpoint, qspec blobcache.QueueSpec) (*blobcache.Handle, error) {
+func CreateQueue(ctx context.Context, tp Asker, ep blobcache.Endpoint, req CreateQueueReq) (CreateQueueResp, error) {
 	var resp CreateQueueResp
-	if err := doAsk(ctx, tp, ep, MT_QUEUE_CREATE, CreateQueueReq{Spec: qspec}, &resp); err != nil {
-		return nil, err
-	}
-	return &resp.Handle, nil
+	err := doAsk(ctx, tp, ep, MT_QUEUE_CREATE, req, &resp)
+	return resp, err
 }
 
 func InspectQueue(ctx context.Context, tp Asker, ep blobcache.Endpoint, qh blobcache.Handle) (blobcache.QueueInfo, error) {

--- a/src/internal/bcp/bcp.go
+++ b/src/internal/bcp/bcp.go
@@ -105,12 +105,12 @@ func OpenFrom(ctx context.Context, tp Asker, ep blobcache.Endpoint, base blobcac
 	return &resp.Handle, &resp.Info, nil
 }
 
-func CreateVolume(ctx context.Context, tp Asker, ep blobcache.Endpoint, vspec blobcache.VolumeSpec) (*blobcache.Handle, error) {
+func CreateVolume(ctx context.Context, tp Asker, ep blobcache.Endpoint, vspec blobcache.VolumeSpec) (*blobcache.Handle, *blobcache.VolumeInfo, error) {
 	var resp CreateVolumeResp
 	if err := doAsk(ctx, tp, ep, MT_CREATE_VOLUME, CreateVolumeReq{Spec: vspec}, &resp); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return &resp.Handle, nil
+	return &resp.Handle, &resp.Info, nil
 }
 
 func BeginTx(ctx context.Context, tp Asker, ep blobcache.Endpoint, volh blobcache.Handle, txp blobcache.TxParams) (*blobcache.Handle, *blobcache.TxInfo, error) {

--- a/src/internal/bcp/rpc_message.go
+++ b/src/internal/bcp/rpc_message.go
@@ -1067,15 +1067,32 @@ func (ir *IsVisitedResp) Unmarshal(data []byte) error {
 }
 
 type CreateVolumeReq struct {
+	Host blobcache.Endpoint
 	Spec blobcache.VolumeSpec
 }
 
 func (cr CreateVolumeReq) Marshal(out []byte) []byte {
-	return cr.Spec.Marshal(out)
+	out = sbe.AppendLP16(out, cr.Host.Marshal(nil))
+	out = sbe.AppendLP16(out, cr.Spec.Marshal(nil))
+	return out
 }
 
 func (cr *CreateVolumeReq) Unmarshal(data []byte) error {
-	return cr.Spec.Unmarshal(data)
+	hostData, data, err := sbe.ReadLP16(data)
+	if err != nil {
+		return err
+	}
+	specData, data, err := sbe.ReadLP16(data)
+	if err != nil {
+		return err
+	}
+	if err := cr.Host.Unmarshal(hostData); err != nil {
+		return err
+	}
+	if err := cr.Spec.Unmarshal(specData); err != nil {
+		return err
+	}
+	return nil
 }
 
 type CreateVolumeResp struct {

--- a/src/internal/bcp/rpc_message.go
+++ b/src/internal/bcp/rpc_message.go
@@ -1117,27 +1117,56 @@ func (cr *CreateVolumeResp) Unmarshal(data []byte) error {
 }
 
 type CreateQueueReq struct {
+	Host blobcache.Endpoint
 	Spec blobcache.QueueSpec
 }
 
 func (cq CreateQueueReq) Marshal(out []byte) []byte {
-	return cq.Spec.Marshal(out)
+	out = sbe.AppendLP16(out, cq.Host.Marshal(nil))
+	out = sbe.AppendLP16(out, cq.Spec.Marshal(nil))
+	return out
 }
 
 func (cq *CreateQueueReq) Unmarshal(data []byte) error {
-	return cq.Spec.Unmarshal(data)
+	hostData, data, err := sbe.ReadLP16(data)
+	if err != nil {
+		return err
+	}
+	specData, data, err := sbe.ReadLP16(data)
+	if err != nil {
+		return err
+	}
+	if err := cq.Host.Unmarshal(hostData); err != nil {
+		return err
+	}
+	if err := cq.Spec.Unmarshal(specData); err != nil {
+		return err
+	}
+	return nil
 }
 
 type CreateQueueResp struct {
 	Handle blobcache.Handle
+	Info   blobcache.QueueInfo
 }
 
 func (cq CreateQueueResp) Marshal(out []byte) []byte {
-	return cq.Handle.Marshal(out)
+	out = cq.Handle.Marshal(out)
+	out = cq.Info.Marshal(out)
+	return out
 }
 
 func (cq *CreateQueueResp) Unmarshal(data []byte) error {
-	return cq.Handle.Unmarshal(data)
+	if len(data) < blobcache.HandleSize {
+		return fmt.Errorf("cannot unmarshal CreateQueueReq, too short: %d", len(data))
+	}
+	if err := cq.Handle.Unmarshal(data[:blobcache.HandleSize]); err != nil {
+		return err
+	}
+	if err := cq.Info.Unmarshal(data[blobcache.HandleSize:]); err != nil {
+		return err
+	}
+	return nil
 }
 
 type DequeueReq struct {

--- a/src/internal/bcp/server.go
+++ b/src/internal/bcp/server.go
@@ -118,7 +118,11 @@ func (s *Server) ServeBCP(ctx context.Context, ep blobcache.Endpoint, req Messag
 		})
 	case MT_CREATE_VOLUME:
 		handleAsk(req, resp, &CreateVolumeReq{}, func(req *CreateVolumeReq) (*CreateVolumeResp, error) {
-			h, err := svc.CreateVolume(ctx, nil, req.Spec)
+			var host *blobcache.Endpoint
+			if req.Host != (blobcache.Endpoint{}) {
+				host = &req.Host
+			}
+			h, err := svc.CreateVolume(ctx, host, req.Spec)
 			if err != nil {
 				return nil, err
 			}

--- a/src/internal/bcsys/bcsys.go
+++ b/src/internal/bcsys/bcsys.go
@@ -789,46 +789,25 @@ func (s *Service[LK, LV, LQ]) CreateVolume(ctx context.Context, host *blobcache.
 // createRemoteVolume calls CreateVolume on a remote node
 // it then creates a new local volume with a new random OID
 func (s *Service[LK, LV, LQ]) createRemoteVolume(ctx context.Context, host blobcache.Endpoint, vspec blobcache.VolumeSpec) (*blobcache.Handle, error) {
-	node, err := s.grabNode(ctx)
-	if err != nil {
-		return nil, err
-	}
-	// the request is for a remote node.
-	rvh, err := bcp.CreateVolume(ctx, node, host, vspec)
-	if err != nil {
-		return nil, err
-	}
-	rvInfo, err := bcp.InspectVolume(ctx, node, host, *rvh)
-	if err != nil {
-		return nil, err
-	}
-	vp, err := s.findVolumeParams(ctx, vspec)
-	if err != nil {
-		return nil, err
+	var vol *remotebe.Volume
+	var err error
+	if host.IPPort.IsValid() && host.IPPort.Port() != 0 {
+		vol, err = s.backends.remote.CreateVolume(ctx, host, vspec)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		vol, err = s.backends.peer.CreateVolume(ctx, host.Node, vspec)
+		if err != nil {
+			return nil, err
+		}
 	}
 	// now we have a handle to the remote volume.
 	// The handle is only valid on the remote node.
-	localInfo := blobcache.VolumeInfo{
-		ID: blobcache.RandomOID(),
-		Backend: blobcache.VolumeBackend[blobcache.OID]{
-			Remote: &blobcache.VolumeBackend_Remote{
-				Endpoint: host,
-				Volume:   rvInfo.ID,
-				HashAlgo: vp.HashAlgo,
-			},
-		},
-	}
-	vol, err := s.backends.remote.VolumeUp(ctx, remotebe.Params{
-		Endpoint: host,
-		Volume:   rvInfo.ID,
-		HashAlgo: vp.HashAlgo,
-	})
-	if err != nil {
-		return nil, err
-	}
-	s.addVolume(localInfo.ID, vol)
+	id := blobcache.RandomOID()
+	s.addVolume(id, vol)
 	// create a local handle
-	localHandle := s.handles.Create(localInfo.ID, blobcache.Action_ALL, time.Now(), time.Now().Add(DefaultVolumeTTL))
+	localHandle := s.handles.Create(id, blobcache.Action_ALL, time.Now(), time.Now().Add(DefaultVolumeTTL))
 	return &localHandle, nil
 }
 


### PR DESCRIPTION
- CreateVolumeReq and CreateQueueReq now take a Host field
- Host field must be zero for PeerView to allow the request through
- CreateQueueResp now includes QueueInfo field.
- blobcachecmd: adds vspec.local command to print a volume spec
- ParseEndpoint does not require an netip.AddrPort, just the NodeID