### PR TITLE
blobcache:  Adds BitMap struct, and changes Exists and IsVisited to use it.

### DIFF
--- a/src/bccore/backend.go
+++ b/src/bccore/backend.go
@@ -33,8 +33,9 @@ type Tx interface {
 	Post(ctx context.Context, data []byte, opts blobcache.PostOpts) (blobcache.CID, error)
 	Get(ctx context.Context, cid blobcache.CID, buf []byte, opts blobcache.GetOpts) (int, error)
 	Delete(ctx context.Context, cids []blobcache.CID) error
-	Exists(ctx context.Context, cids []blobcache.CID, dst []bool) error
-	IsVisited(ctx context.Context, cids []blobcache.CID, dst []bool) error
+	Exists(ctx context.Context, cids []blobcache.CID, dst *blobcache.BitMap) error
+
+	IsVisited(ctx context.Context, cids []blobcache.CID, dst *blobcache.BitMap) error
 	Visit(ctx context.Context, cids []blobcache.CID) error
 
 	MaxSize() int

--- a/src/bccore/txapi.go
+++ b/src/bccore/txapi.go
@@ -111,12 +111,9 @@ func (sys *System) Post(ctx context.Context, txh blobcache.Handle, data []byte, 
 	return cid, nil
 }
 
-func (sys *System) Exists(ctx context.Context, txh blobcache.Handle, cids []blobcache.CID, dst []bool) error {
+func (sys *System) Exists(ctx context.Context, txh blobcache.Handle, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	logctx.Debug(ctx, "begin", zap.String("method", "Exists"), zap.Stringer("oid", txh.OID))
 	defer logctx.Debug(ctx, "done", zap.String("method", "Exists"), zap.Stringer("oid", txh.OID))
-	if len(cids) != len(dst) {
-		return fmt.Errorf("cids and dst must have the same length")
-	}
 	txn, err := sys.resolveTx(txh, true, blobcache.Action_TX_EXISTS)
 	if err != nil {
 		return err
@@ -194,7 +191,7 @@ func (sys *System) Copy(ctx context.Context, txh blobcache.Handle, srcTxns []blo
 	}
 
 	var buf []byte
-	var exists [1]bool
+	var exists blobcache.BitMap
 	for i, cid := range cids {
 		if len(resolvedSrcs) == 0 {
 			continue
@@ -202,11 +199,11 @@ func (sys *System) Copy(ctx context.Context, txh blobcache.Handle, srcTxns []blo
 		start := int(cid[0]) % len(resolvedSrcs)
 		for j := range resolvedSrcs {
 			src := resolvedSrcs[(start+j)%len(resolvedSrcs)]
-			exists[0] = false
-			if err := src.tx.backend.Exists(ctx, []blobcache.CID{cid}, exists[:]); err != nil {
+			exists = exists[:0]
+			if err := src.tx.backend.Exists(ctx, []blobcache.CID{cid}, &exists); err != nil {
 				return fmt.Errorf("copy from tx %v: %w", src.oid, err)
 			}
-			if !exists[0] {
+			if !exists.IsSet(0) {
 				continue
 			}
 			srcMax := src.tx.backend.MaxSize()
@@ -252,12 +249,9 @@ func (sys *System) Visit(ctx context.Context, txh blobcache.Handle, cids []blobc
 	return setErrTxOID(txn.backend.Visit(ctx, cids), txh.OID)
 }
 
-func (sys *System) IsVisited(ctx context.Context, txh blobcache.Handle, cids []blobcache.CID, dst []bool) error {
+func (sys *System) IsVisited(ctx context.Context, txh blobcache.Handle, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	logctx.Debug(ctx, "begin", zap.String("method", "IsVisited"), zap.Stringer("oid", txh.OID))
 	defer logctx.Debug(ctx, "done", zap.String("method", "IsVisited"), zap.Stringer("oid", txh.OID))
-	if len(cids) != len(dst) {
-		return fmt.Errorf("cids and out must have the same length")
-	}
 	txn, err := sys.resolveTx(txh, true, blobcache.Action_TX_IS_VISITED)
 	if err != nil {
 		return err

--- a/src/bchttp/client.go
+++ b/src/bchttp/client.go
@@ -210,13 +210,17 @@ func (c *Client) Post(ctx context.Context, tx blobcache.Handle, data []byte, opt
 	return cid, nil
 }
 
-func (c *Client) Exists(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID, dst []bool) error {
+func (c *Client) Exists(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	req := ExistsReq{CIDs: cids}
 	var resp ExistsResp
 	if err := c.doJSON(ctx, "POST", c.mkTxURL(tx, "Exists"), &tx.Secret, req, &resp); err != nil {
 		return err
 	}
-	copy(dst, resp.Exists)
+	for i, ok := range resp.Exists {
+		if ok {
+			dst.Set(i)
+		}
+	}
 	return nil
 }
 
@@ -277,13 +281,17 @@ func (c *Client) Visit(ctx context.Context, tx blobcache.Handle, cids []blobcach
 	return c.doJSON(ctx, "POST", fmt.Sprintf("/tx/%s.Visit", tx.OID.String()), &tx.Secret, req, &resp)
 }
 
-func (c *Client) IsVisited(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID, out []bool) error {
+func (c *Client) IsVisited(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID, out *blobcache.BitMap) error {
 	req := IsVisitedReq{CIDs: cids}
 	var resp IsVisitedResp
 	if err := c.doJSON(ctx, "POST", fmt.Sprintf("/tx/%s.IsVisited", tx.OID.String()), &tx.Secret, req, &resp); err != nil {
 		return err
 	}
-	copy(out, resp.Visited)
+	for i, ok := range resp.Visited {
+		if ok {
+			out.Set(i)
+		}
+	}
 	return nil
 }
 

--- a/src/bchttp/server.go
+++ b/src/bchttp/server.go
@@ -255,9 +255,13 @@ func (s *Server) handleTx(w http.ResponseWriter, r *http.Request) {
 		})
 	case "Exists":
 		handleRequest(w, r, func(ctx context.Context, req ExistsReq) (*ExistsResp, error) {
-			exists := make([]bool, len(req.CIDs))
-			if err := s.Service.Exists(ctx, h, req.CIDs, exists); err != nil {
+			var existsBM blobcache.BitMap
+			if err := s.Service.Exists(ctx, h, req.CIDs, &existsBM); err != nil {
 				return nil, err
+			}
+			exists := make([]bool, len(req.CIDs))
+			for i := range req.CIDs {
+				exists[i] = existsBM.IsSet(i)
 			}
 			return &ExistsResp{Exists: exists}, nil
 		})
@@ -270,9 +274,13 @@ func (s *Server) handleTx(w http.ResponseWriter, r *http.Request) {
 		})
 	case "IsVisited":
 		handleRequest(w, r, func(ctx context.Context, req IsVisitedReq) (*IsVisitedResp, error) {
-			visited := make([]bool, len(req.CIDs))
-			if err := s.Service.IsVisited(ctx, h, req.CIDs, visited); err != nil {
+			var visitedBM blobcache.BitMap
+			if err := s.Service.IsVisited(ctx, h, req.CIDs, &visitedBM); err != nil {
 				return nil, err
+			}
+			visited := make([]bool, len(req.CIDs))
+			for i := range req.CIDs {
+				visited[i] = visitedBM.IsSet(i)
 			}
 			return &IsVisitedResp{Visited: visited}, nil
 		})

--- a/src/bcipc/client.go
+++ b/src/bcipc/client.go
@@ -149,10 +149,7 @@ func (c *Client) Post(ctx context.Context, tx blobcache.Handle, data []byte, opt
 }
 
 // Exists checks if a CID exists in the volume
-func (c *Client) Exists(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID, dst []bool) error {
-	if len(cids) != len(dst) {
-		return fmt.Errorf("cids and dst must have the same length")
-	}
+func (c *Client) Exists(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	return bcp.Exists(ctx, &c.tp, blobcache.Endpoint{}, tx, cids, dst)
 }
 
@@ -181,7 +178,7 @@ func (c *Client) Visit(ctx context.Context, tx blobcache.Handle, cids []blobcach
 	return bcp.Visit(ctx, &c.tp, blobcache.Endpoint{}, tx, cids)
 }
 
-func (c *Client) IsVisited(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID, dst []bool) error {
+func (c *Client) IsVisited(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	return bcp.IsVisited(ctx, &c.tp, blobcache.Endpoint{}, tx, cids, dst)
 }
 

--- a/src/bclocal/bclocal.go
+++ b/src/bclocal/bclocal.go
@@ -318,7 +318,7 @@ func (s *Service) Post(ctx context.Context, txh blobcache.Handle, data []byte, o
 	return s.sys.Post(ctx, txh, data, opts)
 }
 
-func (s *Service) Exists(ctx context.Context, txh blobcache.Handle, cids []blobcache.CID, dst []bool) error {
+func (s *Service) Exists(ctx context.Context, txh blobcache.Handle, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	return s.sys.Exists(ctx, txh, cids, dst)
 }
 
@@ -338,7 +338,7 @@ func (s *Service) Visit(ctx context.Context, txh blobcache.Handle, cids []blobca
 	return s.sys.Visit(ctx, txh, cids)
 }
 
-func (s *Service) IsVisited(ctx context.Context, txh blobcache.Handle, cids []blobcache.CID, dst []bool) error {
+func (s *Service) IsVisited(ctx context.Context, txh blobcache.Handle, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	return s.sys.IsVisited(ctx, txh, cids, dst)
 }
 

--- a/src/bclocal/internal/localvol/system.go
+++ b/src/bclocal/internal/localvol/system.go
@@ -440,7 +440,7 @@ func (s *System) deleteBlob(volID ID, mvid pdb.MVTag, cids []blobcache.CID) erro
 	})
 }
 
-func (s *System) blobExists(volID ID, mvid pdb.MVTag, cids []blobcache.CID, dst []bool) error {
+func (s *System) blobExists(volID ID, mvid pdb.MVTag, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	sn := s.db.NewSnapshot()
 	defer sn.Close()
 	active := make(pdb.MVSet)
@@ -460,7 +460,9 @@ func (s *System) blobExists(volID ID, mvid pdb.MVTag, cids []blobcache.CID, dst 
 		if err != nil {
 			return err
 		}
-		dst[i] = exists
+		if exists {
+			dst.Set(i)
+		}
 	}
 	return nil
 }
@@ -504,7 +506,7 @@ func (s *System) visit(volID ID, mvid pdb.MVTag, cids []blobcache.CID) error {
 	})
 }
 
-func (s *System) isVisited(volID ID, mvid pdb.MVTag, cids []blobcache.CID, dst []bool) error {
+func (s *System) isVisited(volID ID, mvid pdb.MVTag, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	return s.doRW(func(ba *pebble.Batch, excluding func(pdb.MVTag) bool) error {
 		for i, cid := range cids {
 			// we only have to check for a specific version.
@@ -521,7 +523,9 @@ func (s *System) isVisited(volID ID, mvid pdb.MVTag, cids []blobcache.CID, dst [
 			if err != nil {
 				return err
 			}
-			dst[i] = isVisit
+			if isVisit {
+				dst.Set(i)
+			}
 		}
 		return nil
 	})

--- a/src/bclocal/internal/localvol/txnro.go
+++ b/src/bclocal/internal/localvol/txnro.go
@@ -99,10 +99,10 @@ func (v *localTxnRO) Post(ctx context.Context, data []byte, opts blobcache.PostO
 }
 
 func (v *localTxnRO) Get(ctx context.Context, cid blobcache.CID, buf []byte, opts blobcache.GetOpts) (int, error) {
-	var exists [1]bool
-	if err := v.Exists(ctx, []blobcache.CID{cid}, exists[:]); err != nil {
+	var exists blobcache.BitMap
+	if err := v.Exists(ctx, []blobcache.CID{cid}, &exists); err != nil {
 		return 0, err
-	} else if !exists[0] {
+	} else if !exists.IsSet(0) {
 		return 0, blobcache.ErrNotFound{CID: cid}
 	}
 	unlock, err := v.checkClosed()
@@ -113,7 +113,7 @@ func (v *localTxnRO) Get(ctx context.Context, cid blobcache.CID, buf []byte, opt
 	return v.sys.readBlobData(cid, buf)
 }
 
-func (v *localTxnRO) Exists(ctx context.Context, cids []blobcache.CID, dst []bool) error {
+func (v *localTxnRO) Exists(ctx context.Context, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	activeTxns, err := v.getExcluded()
 	if err != nil {
 		return err
@@ -123,7 +123,9 @@ func (v *localTxnRO) Exists(ctx context.Context, cids []blobcache.CID, dst []boo
 		if err != nil {
 			return err
 		}
-		dst[i] = exists
+		if exists {
+			dst.Set(i)
+		}
 	}
 	return nil
 }
@@ -160,7 +162,7 @@ func (v *localTxnRO) Visit(ctx context.Context, cids []blobcache.CID) error {
 	return blobcache.ErrTxReadOnly{Op: "Visit"}
 }
 
-func (v *localTxnRO) IsVisited(ctx context.Context, cids []blobcache.CID, dst []bool) error {
+func (v *localTxnRO) IsVisited(ctx context.Context, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	return blobcache.ErrTxReadOnly{Op: "IsVisited"}
 }
 

--- a/src/bclocal/internal/localvol/volume.go
+++ b/src/bclocal/internal/localvol/volume.go
@@ -244,7 +244,7 @@ func (txn *localTxnMut) Get(ctx context.Context, cid blobcache.CID, buf []byte, 
 	return txn.localSys.getBlob(txn.vol.lvid, txn.mvid, cid, buf)
 }
 
-func (txn *localTxnMut) Exists(ctx context.Context, cids []blobcache.CID, dst []bool) error {
+func (txn *localTxnMut) Exists(ctx context.Context, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	unlock, err := txn.checkFinished()
 	if err != nil {
 		return err
@@ -265,7 +265,7 @@ func (txn *localTxnMut) Visit(ctx context.Context, cids []blobcache.CID) error {
 	return txn.localSys.visit(txn.vol.lvid, txn.mvid, cids)
 }
 
-func (txn *localTxnMut) IsVisited(ctx context.Context, cids []blobcache.CID, dst []bool) error {
+func (txn *localTxnMut) IsVisited(ctx context.Context, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	unlock, err := txn.checkFinished()
 	if err != nil {
 		return err

--- a/src/bclocal/migrate_link_hashes.go
+++ b/src/bclocal/migrate_link_hashes.go
@@ -243,7 +243,14 @@ func (s nsStore) Get(ctx context.Context, cid blobcache.CID, buf []byte) (int, e
 }
 
 func (s nsStore) Exists(ctx context.Context, cids []blobcache.CID, dst []bool) error {
-	return s.tx.Exists(ctx, cids, dst)
+	var bm blobcache.BitMap
+	if err := s.tx.Exists(ctx, cids, &bm); err != nil {
+		return err
+	}
+	for i := range cids {
+		dst[i] = bm.IsSet(i)
+	}
+	return nil
 }
 
 func (s nsStore) Hash(data []byte) blobcache.CID {

--- a/src/bcp/bcp.go
+++ b/src/bcp/bcp.go
@@ -229,12 +229,12 @@ func Get(ctx context.Context, tp Asker, ep blobcache.Endpoint, txh blobcache.Han
 	return len(respMsg.Body()), nil
 }
 
-func Exists(ctx context.Context, tp Asker, ep blobcache.Endpoint, tx blobcache.Handle, cids []blobcache.CID, dst []bool) error {
+func Exists(ctx context.Context, tp Asker, ep blobcache.Endpoint, tx blobcache.Handle, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	var resp ExistsResp
 	if err := doAsk(ctx, tp, ep, MT_TX_EXISTS, ExistsReq{Tx: tx, CIDs: cids}, &resp); err != nil {
 		return err
 	}
-	copy(dst, resp.Exists)
+	dst.OR(resp.Exists)
 	return nil
 }
 
@@ -263,15 +263,12 @@ func Visit(ctx context.Context, tp Asker, ep blobcache.Endpoint, tx blobcache.Ha
 	return nil
 }
 
-func IsVisited(ctx context.Context, tp Asker, ep blobcache.Endpoint, tx blobcache.Handle, cids []blobcache.CID, dst []bool) error {
-	if len(cids) != len(dst) {
-		return fmt.Errorf("cids and dst must have the same length")
-	}
+func IsVisited(ctx context.Context, tp Asker, ep blobcache.Endpoint, tx blobcache.Handle, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	var resp IsVisitedResp
 	if err := doAsk(ctx, tp, ep, MT_TX_IS_VISITED, IsVisitedReq{Tx: tx, CIDs: cids}, &resp); err != nil {
 		return err
 	}
-	copy(dst, resp.Visited)
+	dst.OR(resp.Visited)
 	return nil
 }
 

--- a/src/bcp/rpc_message.go
+++ b/src/bcp/rpc_message.go
@@ -589,33 +589,16 @@ func (er *ExistsReq) Unmarshal(data []byte) error {
 }
 
 type ExistsResp struct {
-	Exists []bool
+	Exists blobcache.BitMap
 }
 
 func (er ExistsResp) Marshal(out []byte) []byte {
-	for i := range er.Exists {
-		if i%8 == 0 {
-			out = append(out, 0)
-		}
-		if er.Exists[i] {
-			out[len(out)-1] |= 1 << (i % 8)
-		}
-	}
+	out = er.Exists.Marshal(out)
 	return out
 }
 
 func (er *ExistsResp) Unmarshal(data []byte) error {
-	er.Exists = er.Exists[:0]
-	for i := range data {
-		for j := 0; j < 8; j++ {
-			if (data[i] & (1 << j)) != 0 {
-				er.Exists = append(er.Exists, true)
-			} else {
-				er.Exists = append(er.Exists, false)
-			}
-		}
-	}
-	return nil
+	return er.Exists.Unmarshal(data)
 }
 
 type DeleteReq struct {
@@ -1035,31 +1018,15 @@ func (ir *IsVisitedReq) Unmarshal(data []byte) error {
 }
 
 type IsVisitedResp struct {
-	Visited []bool
+	Visited blobcache.BitMap
 }
 
 func (ir IsVisitedResp) Marshal(out []byte) []byte {
-	for i := range ir.Visited {
-		if i%8 == 0 {
-			out = append(out, 0)
-		}
-		if ir.Visited[i] {
-			out[len(out)-1] |= 1 << (i % 8)
-		}
-	}
-	return out
+	return ir.Visited.Marshal(out)
 }
 
 func (ir *IsVisitedResp) Unmarshal(data []byte) error {
-	ir.Visited = make([]bool, len(data)*8)
-	for i := range data {
-		for j := 0; j < 8; j++ {
-			if (data[i] & (1 << j)) != 0 {
-				ir.Visited[i*8+j] = true
-			}
-		}
-	}
-	return nil
+	return ir.Visited.Unmarshal(data)
 }
 
 type CreateVolumeReq struct {

--- a/src/bcp/server.go
+++ b/src/bcp/server.go
@@ -194,8 +194,8 @@ func (s *Server) ServeBCP(ctx context.Context, ep blobcache.Endpoint, req Messag
 		})
 	case MT_TX_EXISTS:
 		handleAsk(req, resp, &ExistsReq{}, func(req *ExistsReq) (*ExistsResp, error) {
-			exists := make([]bool, len(req.CIDs))
-			if err := svc.Exists(ctx, req.Tx, req.CIDs, exists); err != nil {
+			var exists blobcache.BitMap
+			if err := svc.Exists(ctx, req.Tx, req.CIDs, &exists); err != nil {
 				return nil, err
 			}
 			return &ExistsResp{Exists: exists}, nil
@@ -332,8 +332,8 @@ func (s *Server) ServeBCP(ctx context.Context, ep blobcache.Endpoint, req Messag
 		})
 	case MT_TX_IS_VISITED:
 		handleAsk(req, resp, &IsVisitedReq{}, func(req *IsVisitedReq) (*IsVisitedResp, error) {
-			visited := make([]bool, len(req.CIDs))
-			if err := svc.IsVisited(ctx, req.Tx, req.CIDs, visited); err != nil {
+			var visited blobcache.BitMap
+			if err := svc.IsVisited(ctx, req.Tx, req.CIDs, &visited); err != nil {
 				return nil, err
 			}
 			return &IsVisitedResp{Visited: visited}, nil

--- a/src/bcremote/bcremote.go
+++ b/src/bcremote/bcremote.go
@@ -195,10 +195,7 @@ func (s *Service) Post(ctx context.Context, tx blobcache.Handle, data []byte, op
 }
 
 // Exists checks if a CID exists in the volume
-func (s *Service) Exists(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID, dst []bool) error {
-	if len(cids) != len(dst) {
-		return fmt.Errorf("cids and dst must have the same length")
-	}
+func (s *Service) Exists(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	return bcp.Exists(ctx, s.node, s.ep, tx, cids, dst)
 }
 
@@ -227,7 +224,7 @@ func (s *Service) Visit(ctx context.Context, tx blobcache.Handle, cids []blobcac
 	return bcp.Visit(ctx, s.node, s.ep, tx, cids)
 }
 
-func (s *Service) IsVisited(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID, dst []bool) error {
+func (s *Service) IsVisited(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	return bcp.IsVisited(ctx, s.node, s.ep, tx, cids, dst)
 }
 

--- a/src/bcsdk/tx.go
+++ b/src/bcsdk/tx.go
@@ -100,7 +100,14 @@ func (tx *Tx) Post(ctx context.Context, data []byte) (CID, error) {
 }
 
 func (tx *Tx) Exists(ctx context.Context, cids []CID, exists []bool) error {
-	return tx.s.Exists(ctx, tx.h, cids, exists)
+	var bm blobcache.BitMap
+	if err := tx.s.Exists(ctx, tx.h, cids, &bm); err != nil {
+		return err
+	}
+	for i := range cids {
+		exists[i] = bm.IsSet(i)
+	}
+	return nil
 }
 
 func (tx *Tx) Delete(ctx context.Context, cids []CID) error {
@@ -141,7 +148,14 @@ func (tx *Tx) Visit(ctx context.Context, cids []CID) error {
 }
 
 func (tx *Tx) IsVisited(ctx context.Context, cids []CID, yesVisited []bool) error {
-	return tx.s.IsVisited(ctx, tx.h, cids, yesVisited)
+	var bm blobcache.BitMap
+	if err := tx.s.IsVisited(ctx, tx.h, cids, &bm); err != nil {
+		return err
+	}
+	for i := range cids {
+		yesVisited[i] = bm.IsSet(i)
+	}
+	return nil
 }
 
 func (tx *Tx) Copy(ctx context.Context, srcs []*Tx, cids []CID, success []bool) error {
@@ -318,11 +332,11 @@ func ModifyTx(ctx context.Context, svc blobcache.Service, volh blobcache.Handle,
 
 // ExistsSingle is a convenience function for checking if a single CID exists using the slice based API.
 func ExistsSingle(ctx context.Context, s interface {
-	Exists(ctx context.Context, txh Handle, cids []CID, dst []bool) error
+	Exists(ctx context.Context, txh Handle, cids []CID, dst *blobcache.BitMap) error
 }, txh Handle, cid CID) (bool, error) {
-	var dst [1]bool
-	if err := s.Exists(ctx, txh, []CID{cid}, dst[:]); err != nil {
+	var dst blobcache.BitMap
+	if err := s.Exists(ctx, txh, []CID{cid}, &dst); err != nil {
 		return false, err
 	}
-	return dst[0], nil
+	return dst.IsSet(0), nil
 }

--- a/src/blobcache/bitmap.go
+++ b/src/blobcache/bitmap.go
@@ -1,0 +1,137 @@
+package blobcache
+
+import (
+	"math/bits"
+
+	"go.brendoncarroll.net/exp/sbe"
+)
+
+// BitMap is a vector of bits where each bit can be set to 0 or 1 independently.
+type BitMap []uint
+
+// IsSet returns true if bit i is true
+func (bm BitMap) IsSet(i int) bool {
+	if i < 0 {
+		return false
+	}
+
+	word := i / bits.UintSize
+	if word >= len(bm) {
+		return false
+	}
+
+	bit := uint(i % bits.UintSize)
+	return bm[word]&(uint(1)<<bit) != 0
+}
+
+// Set causes bit i to be true/1
+func (bm *BitMap) Set(i int) {
+	if i < 0 {
+		return
+	}
+	word := i / bits.UintSize
+	if word >= len(*bm) {
+		grown := make(BitMap, word+1)
+		copy(grown, *bm)
+		*bm = grown
+	}
+	bit := uint(i % bits.UintSize)
+	(*bm)[word] |= uint(1) << bit
+}
+
+// Unset causes bit i to be false/0
+func (bm *BitMap) Unset(i int) {
+	if i < 0 {
+		return
+	}
+	word := i / bits.UintSize
+	if word >= len(*bm) {
+		return
+	}
+	bit := uint(i % bits.UintSize)
+	(*bm)[word] &^= uint(1) << bit
+}
+
+// Reset sets all bits in the bitmap to 0
+func (bm *BitMap) Reset() {
+	clear(*bm)
+}
+
+// Len returns the number of bits currently represented in the bitmap
+func (bm *BitMap) Len() int {
+	return len(*bm) * bits.UintSize
+}
+
+// OR sets the bit map to be equal to itself bitwised OR'd with o
+func (bm *BitMap) OR(o BitMap) {
+	for i := 0; i < o.Len(); i++ {
+		if o.IsSet(i) {
+			bm.Set(i)
+		}
+	}
+}
+
+func (bm *BitMap) Marshal(out []byte) []byte {
+	switch bits.UintSize {
+	case 32:
+		for _, x := range *bm {
+			out = sbe.AppendUint32(out, uint32(x))
+		}
+	case 64:
+		for _, x := range *bm {
+			out = sbe.AppendUint64(out, uint64(x))
+		}
+	default:
+		panic(bits.UintSize)
+	}
+	return out
+}
+
+func (bm *BitMap) Unmarshal(data []byte) error {
+	wordSize := bits.UintSize / 8
+	n := (len(data) + wordSize - 1) / wordSize
+	if cap(*bm) < n {
+		*bm = make(BitMap, n)
+	} else {
+		*bm = (*bm)[:n]
+	}
+	clear(*bm)
+
+	switch bits.UintSize {
+	case 32:
+		for i := range *bm {
+			if len(data) >= 4 {
+				x, rest, err := sbe.ReadUint32(data)
+				if err != nil {
+					return err
+				}
+				(*bm)[i] = uint(x)
+				data = rest
+				continue
+			}
+			for j, b := range data {
+				(*bm)[i] |= uint(b) << (8 * j)
+			}
+			data = nil
+		}
+	case 64:
+		for i := range *bm {
+			if len(data) >= 8 {
+				x, rest, err := sbe.ReadUint64(data)
+				if err != nil {
+					return err
+				}
+				(*bm)[i] = uint(x)
+				data = rest
+				continue
+			}
+			for j, b := range data {
+				(*bm)[i] |= uint(b) << (8 * j)
+			}
+			data = nil
+		}
+	default:
+		panic(bits.UintSize)
+	}
+	return nil
+}

--- a/src/blobcache/blobcachetests/tx.go
+++ b/src/blobcache/blobcachetests/tx.go
@@ -97,6 +97,27 @@ func TxAPI(t *testing.T, mk func(t testing.TB) (blobcache.Service, blobcache.Han
 		Delete(t, s, txh, hf(data1))
 		require.False(t, Exists(t, s, txh, hf(data1)))
 	})
+	t.Run("ExistsDoesNotUnsetBits", func(t *testing.T) {
+		ctx := testutil.Context(t)
+		s, volh := mk(t)
+		txh := BeginTx(t, s, volh, blobcache.TxParams{Modify: true})
+
+		cids := []blobcache.CID{
+			Post(t, s, txh, []byte("blob 1"), blobcache.PostOpts{}),
+			Post(t, s, txh, []byte("blob 2"), blobcache.PostOpts{}),
+			Post(t, s, txh, []byte("blob 3"), blobcache.PostOpts{}),
+		}
+		cids = append(cids, blobcache.CID{})
+
+		var bm blobcache.BitMap
+		bm.Set(len(cids) - 1) // set the zero CID to true
+
+		require.NoError(t, s.Exists(ctx, txh, cids, &bm))
+		// check that all bits are set
+		for i := range cids {
+			require.True(t, bm.IsSet(i))
+		}
+	})
 	t.Run("1WriterNReaders", func(t *testing.T) {
 		s, volh := mk(t)
 

--- a/src/blobcache/blobcachetests/util.go
+++ b/src/blobcache/blobcachetests/util.go
@@ -156,8 +156,12 @@ func Endpoint(t testing.TB, s blobcache.Service) blobcache.Endpoint {
 
 func IsVisited(t testing.TB, s blobcache.Service, txh blobcache.Handle, cids []blobcache.CID) []bool {
 	ctx := testutil.Context(t)
+	var bm blobcache.BitMap
 	visited := make([]bool, len(cids))
-	require.NoError(t, s.IsVisited(ctx, txh, cids, visited))
+	require.NoError(t, s.IsVisited(ctx, txh, cids, &bm))
+	for i := range cids {
+		visited[i] = bm.IsSet(i)
+	}
 	return visited
 }
 

--- a/src/blobcache/volume.go
+++ b/src/blobcache/volume.go
@@ -141,7 +141,9 @@ type TxAPI interface {
 	Get(ctx context.Context, tx Handle, cid CID, buf []byte, opts GetOpts) (int, error)
 	// Exists checks if several CID exists in the volume
 	// len(dst) must be equal to len(cids), or Exists will return an error.
-	Exists(ctx context.Context, tx Handle, cids []CID, dst []bool) error
+	// Exists only calls Set on the Bitmap, and never Unset.
+	// The caller should call Reset on the bitmap if they want the exact result.
+	Exists(ctx context.Context, tx Handle, cids []CID, dst *BitMap) error
 	// Delete deletes a CID from the volume
 	Delete(ctx context.Context, tx Handle, cids []CID) error
 	// Copy has the same effect as Post, but it does not require sending the data to Blobcache.
@@ -156,7 +158,9 @@ type TxAPI interface {
 	Visit(ctx context.Context, tx Handle, cids []CID) error
 	// IsVisited is only usable in a GC transaction.
 	// It checks if each CID has been visited.
-	IsVisited(ctx context.Context, tx Handle, cids []CID, yesVisited []bool) error
+	// IsVisited only calls Set on the bitmap, to get an exact result, ensure that
+	// Reset has been called.
+	IsVisited(ctx context.Context, tx Handle, cids []CID, yesVisited *BitMap) error
 
 	// Link adds a link to another volume.
 	// All Link operations take effect atomically on Commit

--- a/src/blobcachecmd/service.go
+++ b/src/blobcachecmd/service.go
@@ -299,23 +299,44 @@ func (s *Service) Get(ctx context.Context, h blobcache.Handle, cid blobcache.CID
 func (s *Service) Exists(ctx context.Context, h blobcache.Handle, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	args := []string{"tx", "exists", h.String()}
 	for _, cid := range cids {
+		if cid.IsZero() {
+			continue
+		}
 		args = append(args, cid.String())
+	}
+	if len(args) == 2 {
+		return nil
 	}
 	var out bytes.Buffer
 	if err := s.run(args, nil, &out); err != nil {
 		return err
 	}
+	// parse output
 	lines := bytes.Split(bytes.TrimSpace(out.Bytes()), []byte{'\n'})
-	idx := 0
+	existsm := make(map[blobcache.CID]struct{})
 	for _, ln := range lines {
 		if len(ln) == 0 {
 			continue
 		}
 		if bytes.HasSuffix(ln, []byte(" YES")) {
-			dst.Set(idx)
-			idx++
+			cid, err := blobcache.ParseCID(string(bytes.TrimSuffix(ln, []byte(" YES"))))
+			if err != nil {
+				return err
+			}
+			existsm[cid] = struct{}{}
 		} else if bytes.HasSuffix(ln, []byte(" NO")) {
-			idx++
+			cid, err := blobcache.ParseCID(string(bytes.TrimSuffix(ln, []byte(" NO"))))
+			if err != nil {
+				return err
+			}
+			_ = cid
+		}
+	}
+
+	// set the bits in dst
+	for i, cid := range cids {
+		if _, exists := existsm[cid]; exists {
+			dst.Set(i)
 		}
 	}
 	return nil
@@ -345,26 +366,44 @@ func (s *Service) Visit(ctx context.Context, h blobcache.Handle, cids []blobcach
 	return s.run(args, nil, nil)
 }
 
-func (s *Service) IsVisited(ctx context.Context, h blobcache.Handle, cids []blobcache.CID, yesVisited *blobcache.BitMap) error {
+func (s *Service) IsVisited(ctx context.Context, h blobcache.Handle, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	args := []string{"tx", "is-visited", h.String()}
+	// prepare input
+	in := make([]byte, 0, len(cids)*(blobcache.CIDSize+1))
 	for _, cid := range cids {
-		args = append(args, cid.String())
+		in = append(in, cid.String()...)
+		in = append(in, '\n')
 	}
 	var out bytes.Buffer
-	if err := s.run(args, nil, &out); err != nil {
+	if err := s.run(args, in, &out); err != nil {
 		return err
 	}
+	// parse output
 	lines := bytes.Split(bytes.TrimSpace(out.Bytes()), []byte{'\n'})
-	idx := 0
+	visitm := make(map[blobcache.CID]struct{})
 	for _, ln := range lines {
 		if len(ln) == 0 {
 			continue
 		}
 		if bytes.HasSuffix(ln, []byte(" YES")) {
-			yesVisited.Set(idx)
-			idx++
+			cid, err := blobcache.ParseCID(string(bytes.TrimSuffix(ln, []byte(" YES"))))
+			if err != nil {
+				return err
+			}
+			visitm[cid] = struct{}{}
 		} else if bytes.HasSuffix(ln, []byte(" NO")) {
-			idx++
+			cid, err := blobcache.ParseCID(string(bytes.TrimSuffix(ln, []byte(" NO"))))
+			if err != nil {
+				return err
+			}
+			_ = cid
+		}
+	}
+
+	// set the bits in dst
+	for i, cid := range cids {
+		if _, exists := visitm[cid]; exists {
+			dst.Set(i)
 		}
 	}
 	return nil

--- a/src/blobcachecmd/service.go
+++ b/src/blobcachecmd/service.go
@@ -296,7 +296,7 @@ func (s *Service) Get(ctx context.Context, h blobcache.Handle, cid blobcache.CID
 	return n, nil
 }
 
-func (s *Service) Exists(ctx context.Context, h blobcache.Handle, cids []blobcache.CID, dst []bool) error {
+func (s *Service) Exists(ctx context.Context, h blobcache.Handle, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	args := []string{"tx", "exists", h.String()}
 	for _, cid := range cids {
 		args = append(args, cid.String())
@@ -312,10 +312,9 @@ func (s *Service) Exists(ctx context.Context, h blobcache.Handle, cids []blobcac
 			continue
 		}
 		if bytes.HasSuffix(ln, []byte(" YES")) {
-			dst[idx] = true
+			dst.Set(idx)
 			idx++
 		} else if bytes.HasSuffix(ln, []byte(" NO")) {
-			dst[idx] = false
 			idx++
 		}
 	}
@@ -346,7 +345,7 @@ func (s *Service) Visit(ctx context.Context, h blobcache.Handle, cids []blobcach
 	return s.run(args, nil, nil)
 }
 
-func (s *Service) IsVisited(ctx context.Context, h blobcache.Handle, cids []blobcache.CID, yesVisited []bool) error {
+func (s *Service) IsVisited(ctx context.Context, h blobcache.Handle, cids []blobcache.CID, yesVisited *blobcache.BitMap) error {
 	args := []string{"tx", "is-visited", h.String()}
 	for _, cid := range cids {
 		args = append(args, cid.String())
@@ -362,10 +361,9 @@ func (s *Service) IsVisited(ctx context.Context, h blobcache.Handle, cids []blob
 			continue
 		}
 		if bytes.HasSuffix(ln, []byte(" YES")) {
-			yesVisited[idx] = true
+			yesVisited.Set(idx)
 			idx++
 		} else if bytes.HasSuffix(ln, []byte(" NO")) {
-			yesVisited[idx] = false
 			idx++
 		}
 	}

--- a/src/blobcachecmd/tx.go
+++ b/src/blobcachecmd/tx.go
@@ -224,9 +224,13 @@ var txExistsCmd = star.Command{
 			return err
 		}
 		cids := cidsParam.Load(c)
+		var existsBM blobcache.BitMap
 		exists := make([]bool, len(cids))
-		if err := svc.Exists(c.Context, txHParam.Load(c), cids, exists); err != nil {
+		if err := svc.Exists(c.Context, txHParam.Load(c), cids, &existsBM); err != nil {
 			return err
+		}
+		for i := range cids {
+			exists[i] = existsBM.IsSet(i)
 		}
 		c.Printf(checkmark + " EXISTS OK\n")
 		for i, cid := range cids {
@@ -287,9 +291,13 @@ var txIsVisitedCmd = star.Command{
 			return err
 		}
 		cids := cidsParam.Load(c)
+		var visitedBM blobcache.BitMap
 		visited := make([]bool, len(cids))
-		if err := svc.IsVisited(c.Context, txHParam.Load(c), cids, visited); err != nil {
+		if err := svc.IsVisited(c.Context, txHParam.Load(c), cids, &visitedBM); err != nil {
 			return err
+		}
+		for i := range cids {
+			visited[i] = visitedBM.IsSet(i)
 		}
 		printOK(c, "IS VISITED")
 		for i, cid := range cidsParam.Load(c) {

--- a/src/blobcachecmd/tx.go
+++ b/src/blobcachecmd/tx.go
@@ -1,8 +1,10 @@
 package blobcachecmd
 
 import (
+	"bufio"
 	"fmt"
 	"io"
+	"strings"
 
 	"blobcache.io/blobcache/src/bclocal"
 	"blobcache.io/blobcache/src/blobcache"
@@ -282,26 +284,37 @@ var txVisitCmd = star.Command{
 
 var txIsVisitedCmd = star.Command{
 	Metadata: star.Metadata{
-		Short: "checks if a blob has been visited in the transaction",
+		Short: "checks if blobs from stdin have been visited in the transaction",
 	},
-	Pos: []star.Positional{txHParam, cidsParam},
+	Pos: []star.Positional{txHParam},
 	F: func(c star.Context) error {
 		svc, err := openService(c)
 		if err != nil {
 			return err
 		}
-		cids := cidsParam.Load(c)
-		var visitedBM blobcache.BitMap
-		visited := make([]bool, len(cids))
-		if err := svc.IsVisited(c.Context, txHParam.Load(c), cids, &visitedBM); err != nil {
+		var cids []blobcache.CID
+		sc := bufio.NewScanner(c.StdIn)
+		for sc.Scan() {
+			line := strings.TrimSpace(sc.Text())
+			if line == "" {
+				continue
+			}
+			cid, err := blobcache.ParseCID(line)
+			if err != nil {
+				return err
+			}
+			cids = append(cids, cid)
+		}
+		if err := sc.Err(); err != nil {
 			return err
 		}
-		for i := range cids {
-			visited[i] = visitedBM.IsSet(i)
+		var visited blobcache.BitMap
+		if err := svc.IsVisited(c.Context, txHParam.Load(c), cids, &visited); err != nil {
+			return err
 		}
 		printOK(c, "IS VISITED")
-		for i, cid := range cidsParam.Load(c) {
-			if visited[i] {
+		for i, cid := range cids {
+			if visited.IsSet(i) {
 				c.Printf("%s YES\n", cid.String())
 			} else {
 				c.Printf("%s NO\n", cid.String())

--- a/src/internal/backend/backend.go
+++ b/src/internal/backend/backend.go
@@ -66,8 +66,12 @@ func (v UnsaltedStore) Delete(ctx context.Context, cids []blobcache.CID) error {
 }
 
 func (v UnsaltedStore) Exists(ctx context.Context, cids []blobcache.CID, dst []bool) error {
-	if err := v.inner.Exists(ctx, cids, dst[:]); err != nil {
+	var bm blobcache.BitMap
+	if err := v.inner.Exists(ctx, cids, &bm); err != nil {
 		return err
+	}
+	for i := range cids {
+		dst[i] = bm.IsSet(i)
 	}
 	return nil
 }

--- a/src/internal/backend/memory/volume.go
+++ b/src/internal/backend/memory/volume.go
@@ -237,7 +237,7 @@ func (tx *Tx) Delete(_ context.Context, cids []blobcache.CID) error {
 	return nil
 }
 
-func (tx *Tx) Exists(_ context.Context, cids []blobcache.CID, dst []bool) error {
+func (tx *Tx) Exists(_ context.Context, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	tx.doneMu.RLock()
 	defer tx.doneMu.RUnlock()
 	if tx.isDone {
@@ -250,19 +250,23 @@ func (tx *Tx) Exists(_ context.Context, cids []blobcache.CID, dst []bool) error 
 	for i, cid := range cids {
 		data, shadowed := tx.blobs[cid]
 		_, base := tx.vol.blobs[cid]
-		dst[i] = (shadowed && data != nil) || (!shadowed && base)
+		if (shadowed && data != nil) || (!shadowed && base) {
+			dst.Set(i)
+		}
 	}
 	return nil
 }
 
-func (tx *Tx) IsVisited(_ context.Context, cids []blobcache.CID, dst []bool) error {
+func (tx *Tx) IsVisited(_ context.Context, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	tx.doneMu.RLock()
 	defer tx.doneMu.RUnlock()
 	tx.blobMu.Lock()
 	defer tx.blobMu.Unlock()
 	for i, cid := range cids {
 		_, exists := tx.blobVisits[cid]
-		dst[i] = exists
+		if exists {
+			dst.Set(i)
+		}
 	}
 	return nil
 }

--- a/src/internal/backend/remotebe/volume.go
+++ b/src/internal/backend/remotebe/volume.go
@@ -212,7 +212,7 @@ func (tx *Tx) Delete(ctx context.Context, cids []blobcache.CID) error {
 	return bcp.Delete(ctx, tx.vol.n, tx.vol.ep, tx.h, cids)
 }
 
-func (tx *Tx) Exists(ctx context.Context, cids []blobcache.CID, dst []bool) error {
+func (tx *Tx) Exists(ctx context.Context, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	return bcp.Exists(ctx, tx.vol.n, tx.vol.ep, tx.h, cids, dst)
 }
 
@@ -224,10 +224,7 @@ func (tx *Tx) HashAlgo() blobcache.HashAlgo {
 	return tx.info.HashAlgo
 }
 
-func (tx *Tx) IsVisited(ctx context.Context, cids []blobcache.CID, dst []bool) error {
-	if len(cids) != len(dst) {
-		return fmt.Errorf("cids and dst must have the same length")
-	}
+func (tx *Tx) IsVisited(ctx context.Context, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	return bcp.IsVisited(ctx, tx.vol.n, tx.vol.ep, tx.h, cids, dst)
 }
 

--- a/src/internal/backend/vaultvol/vault.go
+++ b/src/internal/backend/vaultvol/vault.go
@@ -322,7 +322,7 @@ func (v *Tx) Delete(ctx context.Context, cids []blobcache.CID) error {
 	return nil
 }
 
-func (v *Tx) Exists(ctx context.Context, cids []blobcache.CID, dst []bool) error {
+func (v *Tx) Exists(ctx context.Context, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	release, err := v.beginOp(ctx)
 	if err != nil {
 		return err
@@ -335,7 +335,7 @@ func (v *Tx) Exists(ctx context.Context, cids []blobcache.CID, dst []bool) error
 	return v.inner.Exists(ctx, ctcids, dst)
 }
 
-func (v *Tx) IsVisited(ctx context.Context, ptcids []blobcache.CID, dst []bool) error {
+func (v *Tx) IsVisited(ctx context.Context, ptcids []blobcache.CID, dst *blobcache.BitMap) error {
 	release, err := v.beginOp(ctx)
 	if err != nil {
 		return err

--- a/src/internal/bcsys/bcsys.go
+++ b/src/internal/bcsys/bcsys.go
@@ -549,7 +549,7 @@ func (s *Service[LK, LV, LQ]) Post(ctx context.Context, txh blobcache.Handle, da
 	return s.core.Post(ctx, txh, data, opts)
 }
 
-func (s *Service[LV, LK, LQ]) Exists(ctx context.Context, txh blobcache.Handle, cids []blobcache.CID, dst []bool) error {
+func (s *Service[LV, LK, LQ]) Exists(ctx context.Context, txh blobcache.Handle, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	return s.core.Exists(ctx, txh, cids, dst)
 }
 
@@ -569,7 +569,7 @@ func (s *Service[LK, LV, LQ]) Visit(ctx context.Context, txh blobcache.Handle, c
 	return s.core.Visit(ctx, txh, cids)
 }
 
-func (s *Service[LK, LV, LQ]) IsVisited(ctx context.Context, txh blobcache.Handle, cids []blobcache.CID, dst []bool) error {
+func (s *Service[LK, LV, LQ]) IsVisited(ctx context.Context, txh blobcache.Handle, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	return s.core.IsVisited(ctx, txh, cids, dst)
 }
 

--- a/src/internal/bcsys/peerview.go
+++ b/src/internal/bcsys/peerview.go
@@ -142,7 +142,7 @@ func (pv *peerView[LK, LV, LQ]) Get(ctx context.Context, tx blobcache.Handle, ci
 	return pv.svc.Get(ctx, pv.incoming(tx), cid, buf, opts)
 }
 
-func (pv *peerView[LK, LV, LQ]) Exists(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID, dst []bool) error {
+func (pv *peerView[LK, LV, LQ]) Exists(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID, dst *blobcache.BitMap) error {
 	return pv.svc.Exists(ctx, pv.incoming(tx), cids, dst)
 }
 
@@ -159,7 +159,8 @@ func (pv *peerView[LK, LV, LQ]) Visit(ctx context.Context, tx blobcache.Handle, 
 	return pv.svc.Visit(ctx, pv.incoming(tx), cids)
 }
 
-func (pv *peerView[LK, LV, LQ]) IsVisited(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID, yesVisited []bool) error {
+
+func (pv *peerView[LK, LV, LQ]) IsVisited(ctx context.Context, tx blobcache.Handle, cids []blobcache.CID, yesVisited *blobcache.BitMap) error {
 	return pv.svc.IsVisited(ctx, pv.incoming(tx), cids, yesVisited)
 }
 


### PR DESCRIPTION
The IsVisited and Exists methods in the TxAPI use a slice of bool to return the binary state (yes exists, no does not) of each CID queried.  While simple, this requires storing a whole byte for a single bit of information.
These changes add a BitMap type, implemented simply as a `[]uint` which allows multiple bits to be represented more efficiently.