### PR TITLE
blobcache: Load from multiple cells

### DIFF
--- a/src/bccore/backend.go
+++ b/src/bccore/backend.go
@@ -28,7 +28,7 @@ type Tx interface {
 	Abort(ctx context.Context) error
 
 	Save(ctx context.Context, src []byte) error
-	Load(ctx context.Context, dst *[]byte) error
+	Load(ctx context.Context, ck blobcache.CellKey, dst *[]byte) error
 
 	Post(ctx context.Context, data []byte, opts blobcache.PostOpts) (blobcache.CID, error)
 	Get(ctx context.Context, cid blobcache.CID, buf []byte, opts blobcache.GetOpts) (int, error)

--- a/src/bccore/bccore.go
+++ b/src/bccore/bccore.go
@@ -65,9 +65,6 @@ type Params struct {
 	// OnLink is called before the object is linked to.
 	// The object must be persisted so that it can be loaded later
 	OnLink func(ctx context.Context, info blobcache.Info, ao AnyObject) error
-	// OnSave, if not nil, is called on Save.
-	// This is where schema checks can be performed.
-	OnSave func(ctx context.Context, vol Volume, tx Tx, root []byte) error
 }
 
 func New(p Params) System {

--- a/src/bccore/txapi.go
+++ b/src/bccore/txapi.go
@@ -66,9 +66,13 @@ func (sys *System) Abort(ctx context.Context, txh blobcache.Handle) error {
 	return nil
 }
 
-func (sys *System) Load(ctx context.Context, txh blobcache.Handle, dst *[]byte) error {
+func (sys *System) Load(ctx context.Context, txh blobcache.Handle, k blobcache.CellKey, dst *[]byte) error {
 	logctx.Debug(ctx, "begin", zap.String("method", "Load"), zap.Stringer("oid", txh.OID))
 	defer logctx.Debug(ctx, "done", zap.String("method", "Load"), zap.Stringer("oid", txh.OID))
+	if k > 0 {
+		*dst = (*dst)[:0]
+		return nil
+	}
 	txn, err := sys.resolveTx(txh, true, blobcache.Action_TX_LOAD)
 	if err != nil {
 		return err

--- a/src/bccore/txapi.go
+++ b/src/bccore/txapi.go
@@ -69,15 +69,11 @@ func (sys *System) Abort(ctx context.Context, txh blobcache.Handle) error {
 func (sys *System) Load(ctx context.Context, txh blobcache.Handle, k blobcache.CellKey, dst *[]byte) error {
 	logctx.Debug(ctx, "begin", zap.String("method", "Load"), zap.Stringer("oid", txh.OID))
 	defer logctx.Debug(ctx, "done", zap.String("method", "Load"), zap.Stringer("oid", txh.OID))
-	if k > 0 {
-		*dst = (*dst)[:0]
-		return nil
-	}
 	txn, err := sys.resolveTx(txh, true, blobcache.Action_TX_LOAD)
 	if err != nil {
 		return err
 	}
-	return setErrTxOID(txn.backend.Load(ctx, dst), txh.OID)
+	return setErrTxOID(txn.backend.Load(ctx, k, dst), txh.OID)
 }
 
 func (sys *System) Save(ctx context.Context, txh blobcache.Handle, root []byte) error {
@@ -89,11 +85,6 @@ func (sys *System) Save(ctx context.Context, txh blobcache.Handle, root []byte) 
 	}
 	if p := tx.backend.Params(); !p.Modify {
 		return blobcache.ErrTxReadOnly{Tx: txh.OID, Op: "SAVE"}
-	}
-	if sys.p.OnSave != nil {
-		if err := sys.p.OnSave(ctx, tx.volume.backend, tx.backend, root); err != nil {
-			return err
-		}
 	}
 	return setErrTxOID(tx.backend.Save(ctx, root), txh.OID)
 }

--- a/src/bchttp/bchttp.go
+++ b/src/bchttp/bchttp.go
@@ -120,7 +120,9 @@ type SaveReq struct {
 
 type SaveResp struct{}
 
-type LoadReq struct{}
+type LoadReq struct {
+	CellKey blobcache.CellKey `json:"cell_key"`
+}
 
 type LoadResp struct {
 	Root []byte `json:"root"`

--- a/src/bchttp/client.go
+++ b/src/bchttp/client.go
@@ -172,8 +172,8 @@ func (c *Client) Save(ctx context.Context, tx blobcache.Handle, root []byte) err
 	return c.doJSON(ctx, "POST", c.mkTxURL(tx, "Save"), &tx.Secret, req, &resp)
 }
 
-func (c *Client) Load(ctx context.Context, tx blobcache.Handle, dst *[]byte) error {
-	req := LoadReq{}
+func (c *Client) Load(ctx context.Context, tx blobcache.Handle, k blobcache.CellKey, dst *[]byte) error {
+	req := LoadReq{CellKey: k}
 	var resp LoadResp
 	if err := c.doJSON(ctx, "POST", c.mkTxURL(tx, "Load"), &tx.Secret, req, &resp); err != nil {
 		return err

--- a/src/bchttp/server.go
+++ b/src/bchttp/server.go
@@ -201,7 +201,7 @@ func (s *Server) handleTx(w http.ResponseWriter, r *http.Request) {
 	case "Load":
 		handleRequest(w, r, func(ctx context.Context, req LoadReq) (*LoadResp, error) {
 			var root []byte
-			if err := s.Service.Load(ctx, h, &root); err != nil {
+			if err := s.Service.Load(ctx, h, req.CellKey, &root); err != nil {
 				return nil, err
 			}
 			return &LoadResp{Root: root}, nil

--- a/src/bcipc/client.go
+++ b/src/bcipc/client.go
@@ -133,8 +133,8 @@ func (c *Client) Abort(ctx context.Context, tx blobcache.Handle) error {
 }
 
 // Load loads the volume root into dst
-func (c *Client) Load(ctx context.Context, tx blobcache.Handle, dst *[]byte) error {
-	return bcp.Load(ctx, &c.tp, blobcache.Endpoint{}, tx, dst)
+func (c *Client) Load(ctx context.Context, tx blobcache.Handle, k blobcache.CellKey, dst *[]byte) error {
+	return bcp.Load(ctx, &c.tp, blobcache.Endpoint{}, tx, k, dst)
 }
 
 // Save writes to the volume root.

--- a/src/bclocal/bclocal.go
+++ b/src/bclocal/bclocal.go
@@ -310,8 +310,8 @@ func (s *Service) Abort(ctx context.Context, txh blobcache.Handle) error {
 	return s.sys.Abort(ctx, txh)
 }
 
-func (s *Service) Load(ctx context.Context, txh blobcache.Handle, dst *[]byte) error {
-	return s.sys.Load(ctx, txh, dst)
+func (s *Service) Load(ctx context.Context, txh blobcache.Handle, k blobcache.CellKey, dst *[]byte) error {
+	return s.sys.Load(ctx, txh, k, dst)
 }
 
 func (s *Service) Post(ctx context.Context, txh blobcache.Handle, data []byte, opts blobcache.PostOpts) (blobcache.CID, error) {

--- a/src/bclocal/internal/localvol/txnro.go
+++ b/src/bclocal/internal/localvol/txnro.go
@@ -63,7 +63,13 @@ func (v *localTxnRO) Commit(ctx context.Context) error {
 	return blobcache.ErrTxReadOnly{Op: "Commit"}
 }
 
-func (v *localTxnRO) Load(ctx context.Context, dst *[]byte) error {
+func (v *localTxnRO) Load(ctx context.Context, ck blobcache.CellKey, dst *[]byte) error {
+	// TODO: for now, we serialize all Volume access, and higher numbered cells
+	// will always be empty
+	if ck > 0 {
+		*dst = (*dst)[:0]
+		return nil
+	}
 	activeTxns, err := v.getExcluded()
 	if err != nil {
 		return err

--- a/src/bclocal/internal/localvol/volume.go
+++ b/src/bclocal/internal/localvol/volume.go
@@ -192,7 +192,13 @@ func (txn *localTxnMut) Save(ctx context.Context, root []byte) error {
 	return lvSave(txn.localSys.db, txn.vol.lvid, txn.mvid, root)
 }
 
-func (txn *localTxnMut) Load(ctx context.Context, dst *[]byte) error {
+func (txn *localTxnMut) Load(ctx context.Context, ck blobcache.CellKey, dst *[]byte) error {
+	// TODO: for now, we serialize all Volume access, and higher numberd cells
+	// will always be empty
+	if ck > 0 {
+		*dst = (*dst)[:0]
+		return nil
+	}
 	unlock, err := txn.checkFinished()
 	if err != nil {
 		return err

--- a/src/bclocal/migrate_link_hashes.go
+++ b/src/bclocal/migrate_link_hashes.go
@@ -223,7 +223,7 @@ func readNamespaceEntries(ctx context.Context, vol *localvol.Volume, ns bcns.Nam
 	defer tx.Abort(ctx)
 
 	var root []byte
-	if err := tx.Load(ctx, &root); err != nil {
+	if err := tx.Load(ctx, 0, &root); err != nil {
 		return nil, err
 	}
 	if len(root) == 0 {

--- a/src/bcp/bcp.go
+++ b/src/bcp/bcp.go
@@ -138,9 +138,9 @@ func Abort(ctx context.Context, tp Asker, ep blobcache.Endpoint, tx blobcache.Ha
 	return nil
 }
 
-func Load(ctx context.Context, tp Asker, ep blobcache.Endpoint, tx blobcache.Handle, dst *[]byte) error {
+func Load(ctx context.Context, tp Asker, ep blobcache.Endpoint, tx blobcache.Handle, k blobcache.CellKey, dst *[]byte) error {
 	var resp LoadResp
-	if err := doAsk(ctx, tp, ep, MT_TX_LOAD, LoadReq{Tx: tx}, &resp); err != nil {
+	if err := doAsk(ctx, tp, ep, MT_TX_LOAD, LoadReq{Tx: tx, CellKey: k}, &resp); err != nil {
 		return err
 	}
 	*dst = append((*dst)[:0], resp.Root...)

--- a/src/bcp/rpc_message.go
+++ b/src/bcp/rpc_message.go
@@ -496,19 +496,34 @@ func (ar *AbortResp) Unmarshal(data []byte) error {
 }
 
 type LoadReq struct {
-	Tx blobcache.Handle
+	Tx      blobcache.Handle
+	CellKey blobcache.CellKey
 }
 
 func (lr LoadReq) Marshal(out []byte) []byte {
 	out = lr.Tx.Marshal(out)
+	out = sbe.AppendUint32(out, uint32(lr.CellKey))
 	return out
 }
 
 func (lr *LoadReq) Unmarshal(data []byte) error {
-	if len(data) < blobcache.HandleSize {
-		return fmt.Errorf("cannot unmarshal LoadReq, too short: %d", len(data))
+	hdata, data, err := sbe.ReadN(data, blobcache.HandleSize)
+	if err != nil {
+		return err
 	}
-	return lr.Tx.Unmarshal(data)
+	if err := lr.Tx.Unmarshal(hdata); err != nil {
+		return err
+	}
+	if len(data) > 0 {
+		ck, _, err := sbe.ReadUint32(data)
+		if err != nil {
+			return err
+		}
+		lr.CellKey = blobcache.CellKey(ck)
+	} else {
+		lr.CellKey = 0
+	}
+	return nil
 }
 
 type LoadResp struct {

--- a/src/bcp/server.go
+++ b/src/bcp/server.go
@@ -180,7 +180,7 @@ func (s *Server) ServeBCP(ctx context.Context, ep blobcache.Endpoint, req Messag
 	case MT_TX_LOAD:
 		handleAsk(req, resp, &LoadReq{}, func(req *LoadReq) (*LoadResp, error) {
 			var root []byte
-			if err := svc.Load(ctx, req.Tx, &root); err != nil {
+			if err := svc.Load(ctx, req.Tx, req.CellKey, &root); err != nil {
 				return nil, err
 			}
 			return &LoadResp{Root: root}, nil

--- a/src/bcremote/bcremote.go
+++ b/src/bcremote/bcremote.go
@@ -179,8 +179,8 @@ func (s *Service) Abort(ctx context.Context, tx blobcache.Handle) error {
 }
 
 // Load loads the volume root into dst
-func (s *Service) Load(ctx context.Context, tx blobcache.Handle, dst *[]byte) error {
-	return bcp.Load(ctx, s.node, s.ep, tx, dst)
+func (s *Service) Load(ctx context.Context, tx blobcache.Handle, k blobcache.CellKey, dst *[]byte) error {
+	return bcp.Load(ctx, s.node, s.ep, tx, k, dst)
 }
 
 // Save writes to the volume root.

--- a/src/bcsdk/bcsdk.go
+++ b/src/bcsdk/bcsdk.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Loader interface {
-	Load(ctx context.Context, dst *[]byte) error
+	Load(ctx context.Context, ck blobcache.CellKey, dst *[]byte) error
 }
 
 type Saver interface {

--- a/src/bcsdk/tx.go
+++ b/src/bcsdk/tx.go
@@ -70,7 +70,7 @@ func (tx *Tx) Save(ctx context.Context, src []byte) error {
 }
 
 func (tx *Tx) Load(ctx context.Context, dst *[]byte) error {
-	return tx.s.Load(ctx, tx.h, dst)
+	return tx.s.Load(ctx, tx.h, 0, dst)
 }
 
 func (tx *Tx) Commit(ctx context.Context) error {
@@ -203,7 +203,7 @@ func (tx *TxSalt) HashAlgo() blobcache.HashAlgo {
 }
 
 func (tx *TxSalt) Load(ctx context.Context, dst *[]byte) error {
-	return tx.s.Load(ctx, tx.h, dst)
+	return tx.s.Load(ctx, tx.h, 0, dst)
 }
 
 func (tx *TxSalt) Save(ctx context.Context, src []byte) error {

--- a/src/bcsdk/tx.go
+++ b/src/bcsdk/tx.go
@@ -69,8 +69,8 @@ func (tx *Tx) Save(ctx context.Context, src []byte) error {
 	return tx.s.Save(ctx, tx.h, src)
 }
 
-func (tx *Tx) Load(ctx context.Context, dst *[]byte) error {
-	return tx.s.Load(ctx, tx.h, 0, dst)
+func (tx *Tx) Load(ctx context.Context, ck blobcache.CellKey, dst *[]byte) error {
+	return tx.s.Load(ctx, tx.h, ck, dst)
 }
 
 func (tx *Tx) Commit(ctx context.Context) error {
@@ -265,7 +265,7 @@ func View(ctx context.Context, svc blobcache.Service, volh blobcache.Handle, fn 
 	}
 	defer tx.Abort(ctx)
 	var root []byte
-	if err := tx.Load(ctx, &root); err != nil {
+	if err := tx.Load(ctx, 0, &root); err != nil {
 		return err
 	}
 	return fn(tx, root)
@@ -281,7 +281,7 @@ func View1[T any](ctx context.Context, svc blobcache.Service, volh blobcache.Han
 	}
 	defer tx.Abort(ctx)
 	var root []byte
-	if err := tx.Load(ctx, &root); err != nil {
+	if err := tx.Load(ctx, 0, &root); err != nil {
 		return zero, err
 	}
 	return fn(tx, root)
@@ -303,7 +303,7 @@ func ModifyTx(ctx context.Context, svc blobcache.Service, volh blobcache.Handle,
 	}
 	defer tx.Abort(ctx)
 	var prev []byte
-	if err := tx.Load(ctx, &prev); err != nil {
+	if err := tx.Load(ctx, 0, &prev); err != nil {
 		return err
 	}
 	next, err := fn(tx, prev)

--- a/src/blobcache/blobcachetests/service.go
+++ b/src/blobcache/blobcachetests/service.go
@@ -41,7 +41,7 @@ func ServiceAPI(t *testing.T, mk func(t testing.TB) blobcache.Service) {
 		require.NoError(t, err)
 		require.NotNil(t, txh)
 		buf := []byte{1, 2, 3} // arbitrary data
-		err = s.Load(ctx, *txh, &buf)
+		err = s.Load(ctx, *txh, 0, &buf)
 		require.NoError(t, err)
 		require.Equal(t, 0, len(buf))
 	})

--- a/src/blobcache/blobcachetests/util.go
+++ b/src/blobcache/blobcachetests/util.go
@@ -119,7 +119,7 @@ func Modify(t testing.TB, s blobcache.Service, volh blobcache.Handle, f func(tx 
 func Load(t testing.TB, s blobcache.Service, txh blobcache.Handle) []byte {
 	ctx := testutil.Context(t)
 	buf := []byte{}
-	require.NoError(t, s.Load(ctx, txh, &buf))
+	require.NoError(t, s.Load(ctx, txh, 0, &buf))
 	if buf == nil {
 		buf = []byte{}
 	}

--- a/src/blobcache/volume.go
+++ b/src/blobcache/volume.go
@@ -123,6 +123,9 @@ const (
 	Action_TX_VISIT_LINKS
 )
 
+// CellKey identifies a cell within a transaction
+type CellKey uint32
+
 type TxAPI interface {
 	// InspectTx returns info about a transaction.
 	InspectTx(ctx context.Context, tx Handle) (*TxInfo, error)
@@ -131,7 +134,7 @@ type TxAPI interface {
 	// Abort aborts a transaction.
 	Abort(ctx context.Context, tx Handle) error
 	// Load loads the volume root into dst
-	Load(ctx context.Context, tx Handle, dst *[]byte) error
+	Load(ctx context.Context, tx Handle, k CellKey, dst *[]byte) error
 	// Save writes to the volume root.
 	// Like all operations in a transaction, Save will not be visible until Commit is called.
 	Save(ctx context.Context, tx Handle, src []byte) error
@@ -404,6 +407,14 @@ type VolumeConfig struct {
 	MaxSize  int64      `json:"max_size"`
 	Salted   bool       `json:"salted"`
 	Deps     []OID      `json:"deps"`
+	MaxCells uint32     `json:max_cells"`
+}
+
+func (v *VolumeConfig) GetMaxCells() uint32 {
+	if v.MaxCells == 0 {
+		return 1
+	}
+	return v.MaxCells
 }
 
 func (v *VolumeConfig) Validate() error {

--- a/src/blobcachecmd/bctui/comp_mlog.go
+++ b/src/blobcachecmd/bctui/comp_mlog.go
@@ -26,7 +26,7 @@ func (c *merklelogComponent) Init(volInfo *blobcache.VolumeInfo) {}
 
 func (c *merklelogComponent) SetState(ctx context.Context, tx *bcsdk.Tx) error {
 	var root []byte
-	if err := tx.Load(ctx, &root); err != nil {
+	if err := tx.Load(ctx, 0, &root); err != nil {
 		return err
 	}
 	state, err := merklelog.Parse(root)

--- a/src/blobcachecmd/bctui/components.go
+++ b/src/blobcachecmd/bctui/components.go
@@ -213,7 +213,7 @@ func (c *noneComponent) Init(_ *blobcache.VolumeInfo) {
 
 func (c *noneComponent) SetState(ctx context.Context, tx *bcsdk.Tx) error {
 	var root []byte
-	if err := tx.Load(ctx, &root); err != nil {
+	if err := tx.Load(ctx, 0, &root); err != nil {
 		return err
 	}
 	header := fmt.Sprintf("CELL DATA (%d bytes):", len(root))

--- a/src/blobcachecmd/glfs.go
+++ b/src/blobcachecmd/glfs.go
@@ -51,7 +51,7 @@ var glfsInitCmd = star.Command{
 			return err
 		}
 		var root []byte
-		if err := tx.Load(ctx, &root); err != nil {
+		if err := tx.Load(ctx, 0, &root); err != nil {
 			return err
 		}
 		if len(root) > 0 {
@@ -94,7 +94,7 @@ var glfsLookCmd = star.Command{
 		}
 		defer tx.Abort(ctx)
 		var root []byte
-		if err := tx.Load(ctx, &root); err != nil {
+		if err := tx.Load(ctx, 0, &root); err != nil {
 			return err
 		}
 		var ref glfs.Ref
@@ -271,7 +271,7 @@ func viewGLFS(ctx context.Context, s blobcache.Service, volh blobcache.Handle, f
 	defer tx.Abort(ctx)
 	ag := glfs.NewMachine()
 	var rootData []byte
-	if err := tx.Load(ctx, &rootData); err != nil {
+	if err := tx.Load(ctx, 0, &rootData); err != nil {
 		return err
 	}
 	root, err := bcglfs.ParseRef(rootData)
@@ -292,7 +292,7 @@ func modifyGLFS(ctx context.Context, s blobcache.Service, volh blobcache.Handle,
 	ag := glfs.NewMachine()
 	// load and parse root
 	var rootData []byte
-	if err := tx.Load(ctx, &rootData); err != nil {
+	if err := tx.Load(ctx, 0, &rootData); err != nil {
 		return err
 	}
 	root, err := bcglfs.ParseRef(rootData)

--- a/src/blobcachecmd/service.go
+++ b/src/blobcachecmd/service.go
@@ -248,7 +248,11 @@ func (s *Service) Commit(ctx context.Context, h blobcache.Handle) error {
 	return s.run([]string{"tx", "commit", h.String()}, nil, nil)
 }
 
-func (s *Service) Load(ctx context.Context, h blobcache.Handle, dst *[]byte) error {
+func (s *Service) Load(ctx context.Context, h blobcache.Handle, k blobcache.CellKey, dst *[]byte) error {
+	if k > 0 {
+		*dst = (*dst)[:0]
+		return nil
+	}
 	var out bytes.Buffer
 	if err := s.run([]string{"tx", "load", h.String()}, nil, &out); err != nil {
 		return err

--- a/src/blobcachecmd/tx.go
+++ b/src/blobcachecmd/tx.go
@@ -137,7 +137,7 @@ var txLoadCmd = star.Command{
 			return err
 		}
 		var root []byte
-		if err := svc.Load(c.Context, txHParam.Load(c), &root); err != nil {
+		if err := svc.Load(c.Context, txHParam.Load(c), 0, &root); err != nil {
 			return err
 		}
 		_, err = c.StdOut.Write(root)

--- a/src/e2etest/e2e_test.go
+++ b/src/e2etest/e2e_test.go
@@ -111,7 +111,7 @@ func TestGLFS(t *testing.T) {
 	tx, err := bcsdk.BeginTx(ctx, svc, *volh, blobcache.TxParams{})
 	require.NoError(t, err)
 	var root []byte
-	require.NoError(t, tx.Load(ctx, &root))
+	require.NoError(t, tx.Load(ctx, 0, &root))
 	ref := new(glfs.Ref)
 	require.NoError(t, json.Unmarshal(root, ref))
 	ref, err = glfs.GetAtPath(ctx, tx, *ref, "hello.txt")

--- a/src/internal/backend/backend.go
+++ b/src/internal/backend/backend.go
@@ -5,6 +5,7 @@ import (
 
 	"blobcache.io/blobcache/src/bccore"
 	"blobcache.io/blobcache/src/blobcache"
+	"blobcache.io/blobcache/src/schema"
 )
 
 type (
@@ -38,7 +39,7 @@ type LinkSet = map[[32]byte]blobcache.OID
 
 func ViewUnsalted(ctx context.Context, tx Tx) (*UnsaltedStore, []byte, error) {
 	var root []byte
-	if err := tx.Load(ctx, &root); err != nil {
+	if err := tx.Load(ctx, 0, &root); err != nil {
 		return nil, nil, err
 	}
 	return NewUnsaltedStore(tx), root, nil
@@ -79,4 +80,33 @@ func (v UnsaltedStore) Hash(data []byte) blobcache.CID {
 
 func (v UnsaltedStore) HashAlgo() blobcache.HashAlgo {
 	return v.inner.HashAlgo()
+}
+
+// TxBased is a Tx which can return a read-only view of it's base.
+type TxBased interface {
+	Tx
+	// Base returns a read-only transaction representing the inital state of the transaction
+	Base() Tx
+}
+
+func CheckSchema(ctx context.Context, sch schema.Schema, tx TxBased, loaded []blobcache.CellKey) error {
+	baseTx := tx.Base()
+	var prevCell []byte
+	if err := baseTx.Load(ctx, 0, &prevCell); err != nil {
+		return err
+	}
+	var nextCell []byte
+	if err := tx.Load(ctx, 0, &nextCell); err != nil {
+		return err
+	}
+	return sch.ValidateChange(ctx, schema.Change{
+		Prev: schema.Value{
+			Cell:  prevCell,
+			Store: NewUnsaltedStore(baseTx),
+		},
+		Next: schema.Value{
+			Cell:  nextCell,
+			Store: NewUnsaltedStore(tx),
+		},
+	})
 }

--- a/src/internal/backend/memory/volume.go
+++ b/src/internal/backend/memory/volume.go
@@ -3,6 +3,8 @@ package memory
 import (
 	"context"
 	"fmt"
+	"iter"
+	"slices"
 	"sync"
 
 	"blobcache.io/blobcache/src/bccore"
@@ -86,6 +88,8 @@ type Tx struct {
 	isDone     bool
 	cellMu     sync.Mutex
 	cell       []byte
+	loaded     []blobcache.CellKey
+	saved      bool
 	blobMu     sync.RWMutex
 	blobs      map[blobcache.CID][]byte
 	blobVisits map[blobcache.CID]struct{}
@@ -145,13 +149,16 @@ func (tx *Tx) Commit(ctx context.Context) error {
 	return nil
 }
 
-func (tx *Tx) Load(ctx context.Context, dst *[]byte) error {
+func (tx *Tx) Load(ctx context.Context, ck blobcache.CellKey, dst *[]byte) error {
 	tx.doneMu.RLock()
 	defer tx.doneMu.RUnlock()
 	tx.cellMu.Lock()
 	defer tx.cellMu.Unlock()
 	if tx.isDone {
 		return blobcache.ErrTxDone{}
+	}
+	if !slices.Contains(tx.loaded, ck) {
+		tx.loaded = append(tx.loaded, ck)
 	}
 	*dst = append((*dst)[:0], tx.cell...)
 	return nil
@@ -167,6 +174,7 @@ func (tx *Tx) Save(ctx context.Context, src []byte) error {
 	if tx.isDone {
 		return blobcache.ErrTxDone{}
 	}
+	tx.saved = true
 	tx.cell = append(tx.cell[:0], src...)
 	return nil
 }
@@ -306,6 +314,18 @@ func (tx *Tx) Unlink(ctx context.Context, targets []blobcache.LinkID) error {
 
 func (tx *Tx) VisitLinks(ctx context.Context, targets []blobcache.LinkID) error {
 	return fmt.Errorf("linking not implemented for memory volumes")
+}
+
+func (tx *Tx) LoadedFrom() iter.Seq[blobcache.CellKey] {
+	tx.cellMu.Lock()
+	defer tx.cellMu.Unlock()
+	return slices.Values(tx.loaded)
+}
+
+func (tx *Tx) Saved() bool {
+	tx.cellMu.Lock()
+	defer tx.cellMu.Unlock()
+	return tx.saved
 }
 
 func copyBlob(buf []byte, cid blobcache.CID, data []byte) (int, error) {

--- a/src/internal/backend/remotebe/volume.go
+++ b/src/internal/backend/remotebe/volume.go
@@ -179,7 +179,7 @@ func (tx *Tx) Abort(ctx context.Context) error {
 }
 
 func (tx *Tx) Load(ctx context.Context, dst *[]byte) error {
-	return bcp.Load(ctx, tx.vol.n, tx.vol.ep, tx.h, dst)
+	return bcp.Load(ctx, tx.vol.n, tx.vol.ep, tx.h, 0, dst)
 }
 
 func (tx *Tx) Save(ctx context.Context, src []byte) error {

--- a/src/internal/backend/remotebe/volume.go
+++ b/src/internal/backend/remotebe/volume.go
@@ -178,8 +178,8 @@ func (tx *Tx) Abort(ctx context.Context) error {
 	return bcp.Abort(ctx, tx.vol.n, tx.vol.ep, tx.h)
 }
 
-func (tx *Tx) Load(ctx context.Context, dst *[]byte) error {
-	return bcp.Load(ctx, tx.vol.n, tx.vol.ep, tx.h, 0, dst)
+func (tx *Tx) Load(ctx context.Context, ck blobcache.CellKey, dst *[]byte) error {
+	return bcp.Load(ctx, tx.vol.n, tx.vol.ep, tx.h, ck, dst)
 }
 
 func (tx *Tx) Save(ctx context.Context, src []byte) error {

--- a/src/internal/backend/vaultvol/vault.go
+++ b/src/internal/backend/vaultvol/vault.go
@@ -141,7 +141,7 @@ func (tx *Tx) Params() blobcache.TxParams {
 	return tx.txp
 }
 
-func (v *Tx) Load(ctx context.Context, dst *[]byte) error {
+func (v *Tx) Load(ctx context.Context, ck blobcache.CellKey, dst *[]byte) error {
 	release, err := v.beginOp(ctx)
 	if err != nil {
 		return err
@@ -460,7 +460,7 @@ func (vtx *Tx) init(ctx context.Context) error {
 		return nil
 	}
 	var rootCtext []byte
-	if err := vtx.inner.Load(ctx, &rootCtext); err != nil {
+	if err := vtx.inner.Load(ctx, 0, &rootCtext); err != nil {
 		return err
 	}
 	var ttx *tries.Tx

--- a/src/internal/bcsys/bcsys.go
+++ b/src/internal/bcsys/bcsys.go
@@ -535,8 +535,8 @@ func (s *Service[LK, LV, LQ]) Abort(ctx context.Context, txh blobcache.Handle) e
 	return s.core.Abort(ctx, txh)
 }
 
-func (s *Service[LK, LV, LQ]) Load(ctx context.Context, txh blobcache.Handle, dst *[]byte) error {
-	return s.core.Load(ctx, txh, dst)
+func (s *Service[LK, LV, LQ]) Load(ctx context.Context, txh blobcache.Handle, k blobcache.CellKey, dst *[]byte) error {
+	return s.core.Load(ctx, txh, k, dst)
 }
 
 func (s *Service[LK, LV, LQ]) Post(ctx context.Context, txh blobcache.Handle, data []byte, opts blobcache.PostOpts) (blobcache.CID, error) {

--- a/src/internal/bcsys/bcsys.go
+++ b/src/internal/bcsys/bcsys.go
@@ -103,30 +103,6 @@ func New[LK any, LV LocalVolume[LK], LQ LocalQueue](env Env[LK, LV, LQ], cfg Con
 		Root:   env.Root,
 		Up:     s.up,
 		OnLink: s.onLink,
-		OnSave: func(ctx context.Context, vol bccore.Volume, tx bccore.Tx, root []byte) error {
-			// validate against the schema.
-			var prevRoot []byte
-			if err := tx.Load(ctx, &prevRoot); err != nil {
-				return err
-			}
-			src := backend.NewUnsaltedStore(tx)
-			schSpec := vol.GetParams().Schema
-			sch, err := env.MkSchema(schSpec)
-			if err != nil {
-				return err
-			}
-			change := schema.Change{
-				Prev: schema.Value{
-					Cell:  prevRoot,
-					Store: src,
-				},
-				Next: schema.Value{
-					Cell:  root,
-					Store: src,
-				},
-			}
-			return sch.ValidateChange(ctx, change)
-		},
 	})
 	return s
 }
@@ -760,4 +736,12 @@ func (s *Service[LK, LV, LQ]) findVolumeParams(ctx context.Context, vspec blobca
 	default:
 		panic(vspec)
 	}
+}
+
+func takeFirst[T any](xs iter.Seq[T]) (T, bool) {
+	for x := range xs {
+		return x, true
+	}
+	var zero T
+	return zero, false
 }

--- a/src/internal/bcsys/peerview.go
+++ b/src/internal/bcsys/peerview.go
@@ -126,8 +126,8 @@ func (pv *peerView[LK, LV, LQ]) Abort(ctx context.Context, tx blobcache.Handle) 
 	return pv.svc.Abort(ctx, pv.incoming(tx))
 }
 
-func (pv *peerView[LK, LV, LQ]) Load(ctx context.Context, tx blobcache.Handle, dst *[]byte) error {
-	return pv.svc.Load(ctx, pv.incoming(tx), dst)
+func (pv *peerView[LK, LV, LQ]) Load(ctx context.Context, tx blobcache.Handle, k blobcache.CellKey, dst *[]byte) error {
+	return pv.svc.Load(ctx, pv.incoming(tx), k, dst)
 }
 
 func (pv *peerView[LK, LV, LQ]) Save(ctx context.Context, tx blobcache.Handle, src []byte) error {

--- a/src/schema/bcfuse/bcfs.go
+++ b/src/schema/bcfuse/bcfs.go
@@ -107,7 +107,7 @@ func (fs *FS[K]) Flush(ctx context.Context) error {
 	defer func() { _ = tx.Abort(ctx) }()
 
 	// Load current root
-	if err := tx.Load(ctx, &fs.root); err != nil {
+	if err := tx.Load(ctx, 0, &fs.root); err != nil {
 		return fmt.Errorf("failed to load root: %w", err)
 	}
 

--- a/src/schema/bcgit/schema.go
+++ b/src/schema/bcgit/schema.go
@@ -37,7 +37,7 @@ type Root struct {
 
 func LoadRoot(ctx context.Context, ldr bcsdk.Loader) (*Root, error) {
 	var rootData []byte
-	if err := ldr.Load(ctx, &rootData); err != nil {
+	if err := ldr.Load(ctx, 0, &rootData); err != nil {
 		return nil, err
 	}
 	if len(rootData) == 0 {

--- a/src/schema/bcglfs/glfs.go
+++ b/src/schema/bcglfs/glfs.go
@@ -87,7 +87,7 @@ func DiffRefs(ctx context.Context, src schema.RO, left, right glfs.Ref, fn func(
 
 func Load(ctx context.Context, txn *bcsdk.Tx) (*glfs.Ref, error) {
 	var root []byte
-	if err := txn.Load(ctx, &root); err != nil {
+	if err := txn.Load(ctx, 0, &root); err != nil {
 		return nil, err
 	}
 	return ParseRef(root)

--- a/src/schema/bcns/bcns.go
+++ b/src/schema/bcns/bcns.go
@@ -293,7 +293,7 @@ func (nsc *Client) GC(ctx context.Context, volh blobcache.Handle) error {
 		return nil
 	}
 	var root []byte
-	if err := tx.Load(ctx, &root); err != nil {
+	if err := tx.Load(ctx, 0, &root); err != nil {
 		return err
 	}
 	if err := gcsch.VisitAll(ctx, tx, root, visit); err != nil {

--- a/src/schema/bcns/tx.go
+++ b/src/schema/bcns/tx.go
@@ -16,7 +16,7 @@ type Tx struct {
 
 func NewFromTx(ctx context.Context, schema Namespace, tx *bcsdk.Tx) (Tx, error) {
 	var cell []byte
-	if err := tx.Load(ctx, &cell); err != nil {
+	if err := tx.Load(ctx, 0, &cell); err != nil {
 		return Tx{}, err
 	}
 	return Tx{

--- a/src/schema/jsonns/jsonns.go
+++ b/src/schema/jsonns/jsonns.go
@@ -124,7 +124,7 @@ type Tx struct {
 }
 
 func (ns *Tx) loadEntries(ctx context.Context) ([]Entry, error) {
-	if err := ns.Tx.Load(ctx, &ns.Root); err != nil {
+	if err := ns.Tx.Load(ctx, 0, &ns.Root); err != nil {
 		return nil, err
 	}
 	ents, err := ns.Schema.NSList(ctx, ns.Tx, ns.Root)

--- a/src/schema/radixkv/radixkv.go
+++ b/src/schema/radixkv/radixkv.go
@@ -78,7 +78,7 @@ func View(ctx context.Context, svc blobcache.Service, volh blobcache.Handle, mac
 
 func wrapTx(ctx context.Context, mach *Machine, tx *bcsdk.Tx) (*Tx, error) {
 	var rootData []byte
-	if err := tx.Load(ctx, &rootData); err != nil {
+	if err := tx.Load(ctx, 0, &rootData); err != nil {
 		return nil, err
 	}
 	if len(rootData) == 0 {


### PR DESCRIPTION
Access to Volume's has always been totally serialized, with the intention that Schema's could eventually be used to special case Volumes where simultaneous write-transactions are allowed.
As was discovered previously with Links, it is always possible and usually better to accomplish the same thing without a Schema, by exposing the right operations.
These changes allow the API to accommodate multiple concurrent transactions, even on encrypted data that the server doesn't understand.
This small change makes it possible to build CRDT's on top of Volumes, which now allow concurrent editing by multiple clients, without requiring the server Node to understand the data structures and how to reconcile them.

The existing behavior of Load and Save is unchanged:
- bcp Load requests that do not include a CellKey will read from the 0 cell implicitly.
- Save continue to work normally.
- The initial state for a Volume has the empty string for the all the cell contents.
- If MaxCells is set to 1 in a Volume Config (the default), then the Volume behaves exactly as it did before this change.

The new behavior is as follows:
- Volumes have a some number of cells, which corresponds to the maximum number of unreconciled versions of the Volume's contents.
- Load can be from any one of the Volume's cells numbered with 32 bit integer keys.
- All non-empty cells are contiguous with 0.  e.g. If cells 0, 1, 2, 3 are non-empty, but 4 is empty, then all cells > 4 are also empty.
- The order of cells is scoped to the transaction, cells will appear in a different order in different transactions.
- If Save is called, all cells that have been loaded from are considered reconciled, and their contents will be lost.

This API is designed so that a CRDT can be read or modified by calling Load until the caller gets to an empty cell.
At that point, all of the versions have been accounted for, and if Save is called, then they can be discarded, now consolidated by the caller into the saved data.